### PR TITLE
[FIX] CI/CD action trigger를 PR open에서 push로 수정합니다.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,7 +1,7 @@
 name: TinU Backend CI/CD
 
 on:
-  pull_request:
+  push:
     branches:
       - develop
 
@@ -13,8 +13,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
 
       # SOURCE 단계 - 저장소 Checkout
       - name: Checkout-source code
@@ -86,7 +86,7 @@ jobs:
           jwt.redirect.sign = ${{ secrets.JWT_REDIRECT_SIGN_URI }}
           EOF
 
-    # docker image 빌드
+      # docker image 빌드
       - name: Build docker image
         run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMAGENAME }} .
 


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #117 

## ✅ 작업 내용

기존에 CI/CD action trigger가 PR open으로 되어있어서 리뷰가 resolve되기 전에 백엔드 배포가 되어버리는 이슈가 있었어요.
리뷰가 다 반영된 후 배포되는 것이 적절하다고 생각해서 trigger를 PR open에서 push로 수정했어요.