### PR TITLE
[FEAT] Custom Filter 관련 단순 로직 (CRUD 완료)

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/domain/category/repository/CategoryRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/category/repository/CategoryRepository.kt
@@ -1,0 +1,7 @@
+package com.tinuproject.tinu.domain.category.repository
+
+import com.tinuproject.tinu.domain.entity.Category
+import org.springframework.data.repository.CrudRepository
+
+interface CategoryRepository : CrudRepository<Category, Long>{
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customcategory/repository/CustomCategoryRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customcategory/repository/CustomCategoryRepository.kt
@@ -1,0 +1,7 @@
+package com.tinuproject.tinu.domain.customcategory.repository
+
+import com.tinuproject.tinu.domain.entity.CustomCategory
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CustomCategoryRepository : JpaRepository<CustomCategory,Long>  {
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customcategory/repository/CustomCategoryRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customcategory/repository/CustomCategoryRepository.kt
@@ -3,9 +3,18 @@ package com.tinuproject.tinu.domain.customcategory.repository
 import com.tinuproject.tinu.domain.entity.CustomCategory
 import com.tinuproject.tinu.domain.entity.CustomFilter
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface CustomCategoryRepository : JpaRepository<CustomCategory,Long>  {
 
+    @Query("delete from CustomCategory c where c.customFilter.id = :customFilterId")
+    @Modifying
+    fun deleteAllByCustomFilterId(@Param("customFilterId") customFilterId: Long)
+
+
     fun deleteAllByCustomFilter(customFilter: CustomFilter)
+
 
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customcategory/repository/CustomCategoryRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customcategory/repository/CustomCategoryRepository.kt
@@ -1,7 +1,11 @@
 package com.tinuproject.tinu.domain.customcategory.repository
 
 import com.tinuproject.tinu.domain.entity.CustomCategory
+import com.tinuproject.tinu.domain.entity.CustomFilter
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CustomCategoryRepository : JpaRepository<CustomCategory,Long>  {
+
+    fun deleteAllByCustomFilter(customFilter: CustomFilter)
+
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/controller/CustomFilterController.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/controller/CustomFilterController.kt
@@ -2,6 +2,8 @@ package com.tinuproject.tinu.domain.customfilter.controller
 
 import com.tinuproject.tinu.DTO.ResponseDTO
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.CreateCustomFilter
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.DeleteCustomFilter
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.service.CustomFilterService
 import com.tinuproject.tinu.domain.member.service.MemberService
 import com.tinuproject.tinu.web.ResponseEntityGenerator
@@ -9,12 +11,18 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.*
 
 
+@Controller
 @RequestMapping("/api/custom-filter")
 class CustomFilterController(
     private val customFilterService: CustomFilterService
@@ -28,7 +36,24 @@ class CustomFilterController(
     }
 
     @PostMapping("")
-    fun createCustomFilter(@AuthenticationPrincipal userId : UUID, createCustomFilter: CreateCustomFilter){
+    fun createCustomFilter(@AuthenticationPrincipal userId : UUID, @RequestBody createCustomFilter: CreateCustomFilter) : ResponseEntity<ResponseDTO>{
         customFilterService.createCustomFilter(userId = userId, createCustomFilter= createCustomFilter)
+        return ResponseEntityGenerator.onSuccess()
+    }
+
+    @PutMapping("/{filterId}")
+    fun updateCustomFilter(@AuthenticationPrincipal userId : UUID, @PathVariable(name = "filterId") filterId : Long,@RequestBody updateCustomFilter: UpdateCustomFilter) : ResponseEntity<ResponseDTO>{
+        updateCustomFilter.filterId = filterId
+
+        customFilterService.updateCustomFilter(userId, updateCustomFilter)
+
+        return ResponseEntityGenerator.onSuccess()
+    }
+
+    @DeleteMapping("/{filterId}")
+    fun deleteCustomFilter(@AuthenticationPrincipal userId : UUID, @PathVariable(name = "filterId") filterId: Long) : ResponseEntity<ResponseDTO>{
+        customFilterService.deleteCustomFilter(userId, DeleteCustomFilter(filterId=filterId))
+
+        return ResponseEntityGenerator.onSuccess()
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/controller/CustomFilterController.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/controller/CustomFilterController.kt
@@ -1,0 +1,27 @@
+package com.tinuproject.tinu.domain.customfilter.controller
+
+import com.tinuproject.tinu.DTO.ResponseDTO
+import com.tinuproject.tinu.domain.customfilter.service.CustomFilterService
+import com.tinuproject.tinu.domain.member.service.MemberService
+import com.tinuproject.tinu.web.ResponseEntityGenerator
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import java.util.*
+
+
+@RequestMapping("/api/custom-filter")
+class CustomFilterController(
+    private val customFilterService: CustomFilterService
+) {
+    val log : Logger = LoggerFactory.getLogger(this::class.java)
+
+
+    @GetMapping("")
+    fun requestCustomFilter(@AuthenticationPrincipal userId : UUID) : ResponseEntity<ResponseDTO> {
+        return ResponseEntityGenerator.onSuccess(customFilterService.getUserCustomFilter(userId))
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/controller/CustomFilterController.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/controller/CustomFilterController.kt
@@ -1,6 +1,7 @@
 package com.tinuproject.tinu.domain.customfilter.controller
 
 import com.tinuproject.tinu.DTO.ResponseDTO
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.CreateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.service.CustomFilterService
 import com.tinuproject.tinu.domain.member.service.MemberService
 import com.tinuproject.tinu.web.ResponseEntityGenerator
@@ -9,6 +10,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import java.util.*
 
@@ -22,6 +24,11 @@ class CustomFilterController(
 
     @GetMapping("")
     fun requestCustomFilter(@AuthenticationPrincipal userId : UUID) : ResponseEntity<ResponseDTO> {
-        return ResponseEntityGenerator.onSuccess(customFilterService.getUserCustomFilter(userId))
+        return ResponseEntityGenerator.onSuccess(customFilterService.getCustomFilter(userId))
+    }
+
+    @PostMapping("")
+    fun createCustomFilter(@AuthenticationPrincipal userId : UUID, createCustomFilter: CreateCustomFilter){
+        customFilterService.createCustomFilter(userId = userId, createCustomFilter= createCustomFilter)
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/CreateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/CreateCustomFilter.kt
@@ -1,0 +1,9 @@
+package com.tinuproject.tinu.domain.customfilter.dto.client_controller.request
+
+data class CreateCustomFilter(
+    val filterName : String,
+    val category : MutableList<Long>,
+    val maxPrice : Int,
+    val minPrice : Int,
+    val isSell : Boolean
+)

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/CreateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/CreateCustomFilter.kt
@@ -2,7 +2,7 @@ package com.tinuproject.tinu.domain.customfilter.dto.client_controller.request
 
 data class CreateCustomFilter(
     val filterName : String,
-    val category : MutableList<Long>,
+    val category : List<Long>,
     val maxPrice : Int,
     val minPrice : Int,
     val isSell : Boolean

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/CreateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/CreateCustomFilter.kt
@@ -5,5 +5,5 @@ data class CreateCustomFilter(
     val category : List<Long>,
     val maxPrice : Int,
     val minPrice : Int,
-    val isSell : Boolean
+    val onlySell : Boolean
 )

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/DeleteCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/DeleteCustomFilter.kt
@@ -1,0 +1,5 @@
+package com.tinuproject.tinu.domain.customfilter.dto.client_controller.request
+
+data class DeleteCustomFilter(
+    val filterId : Long
+)

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
@@ -6,7 +6,7 @@ data class UpdateCustomFilter(
     val filterId : Long?,
     val filterName : String,
     val category : MutableList<Long>,
-    val maxPrice : Int,
-    val minPrice : Int,
-    val isSell : Boolean
+    val maxPrice : Int?,
+    val minPrice : Int?,
+    val isSell : Boolean?
 )

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
@@ -3,9 +3,9 @@ package com.tinuproject.tinu.domain.customfilter.dto.client_controller.request
 import org.jetbrains.annotations.NotNull
 
 data class UpdateCustomFilter(
-    val filterId : Long?,
+    var filterId : Long?,
     val filterName : String,
-    val category : MutableList<Long>,
+    val category : List<Long>,
     val maxPrice : Int?,
     val minPrice : Int?,
     val isSell : Boolean?

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
@@ -1,0 +1,12 @@
+package com.tinuproject.tinu.domain.customfilter.dto.client_controller.request
+
+import org.jetbrains.annotations.NotNull
+
+data class UpdateCustomFilter(
+    val filterId : Long?,
+    val filterName : String,
+    val category : MutableList<Long>,
+    val maxPrice : Int,
+    val minPrice : Int,
+    val isSell : Boolean
+)

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/request/UpdateCustomFilter.kt
@@ -8,5 +8,5 @@ data class UpdateCustomFilter(
     val category : List<Long>,
     val maxPrice : Int?,
     val minPrice : Int?,
-    val isSell : Boolean?
+    val onlySell : Boolean?
 )

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/response/SelectCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/response/SelectCustomFilter.kt
@@ -6,5 +6,5 @@ data class SelectCustomFilter(
     val category: MutableList<Long>,
     val maxPrice: Int?,
     val minPrice: Int?,
-    val isSell: Boolean?
+    val onlySell: Boolean?
 )

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/response/SelectCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/dto/client_controller/response/SelectCustomFilter.kt
@@ -1,0 +1,10 @@
+package com.tinuproject.tinu.domain.customfilter.dto.client_controller.response
+
+data class SelectCustomFilter(
+    val filterId : Long,
+    val filterName: String,
+    val category: MutableList<Long>,
+    val maxPrice: Int?,
+    val minPrice: Int?,
+    val isSell: Boolean?
+)

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/repository/CustomFilterRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/repository/CustomFilterRepository.kt
@@ -4,4 +4,5 @@ import com.tinuproject.tinu.domain.entity.CustomFilter
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CustomFilterRepository : JpaRepository<CustomFilter, Long> {
+    fun findCustomFilterById(id : Long) : CustomFilter?
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/repository/CustomFilterRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/repository/CustomFilterRepository.kt
@@ -1,4 +1,7 @@
 package com.tinuproject.tinu.domain.customfilter.repository
 
-interface CustomFilterRepository {
+import com.tinuproject.tinu.domain.entity.CustomFilter
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CustomFilterRepository : JpaRepository<CustomFilter, Long> {
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/repository/CustomFilterRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/repository/CustomFilterRepository.kt
@@ -1,0 +1,4 @@
+package com.tinuproject.tinu.domain.customfilter.repository
+
+interface CustomFilterRepository {
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterService.kt
@@ -1,11 +1,16 @@
 package com.tinuproject.tinu.domain.customfilter.service
 
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.CreateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.SelectCustomFilter
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 interface CustomFilterService {
-    fun getUserCustomFilter(userId : UUID) : List<SelectCustomFilter>
 
-    fun updateUserCustomFilter(userId : UUID, updateCustomFilter: UpdateCustomFilter)
+    fun getCustomFilter(userId : UUID) : List<SelectCustomFilter>
+
+    fun createCustomFilter(userId : UUID, createCustomFilter: CreateCustomFilter)
+
+    fun updateCustomFilter(userId : UUID, updateCustomFilter: UpdateCustomFilter)
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterService.kt
@@ -1,6 +1,7 @@
 package com.tinuproject.tinu.domain.customfilter.service
 
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.CreateCustomFilter
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.DeleteCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.SelectCustomFilter
 import org.springframework.transaction.annotation.Transactional
@@ -13,4 +14,6 @@ interface CustomFilterService {
     fun createCustomFilter(userId : UUID, createCustomFilter: CreateCustomFilter)
 
     fun updateCustomFilter(userId : UUID, updateCustomFilter: UpdateCustomFilter)
+
+    fun deleteCustomFilter(userId : UUID, deleteCustomFilter: DeleteCustomFilter)
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterService.kt
@@ -1,0 +1,11 @@
+package com.tinuproject.tinu.domain.customfilter.service
+
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.SelectCustomFilter
+import java.util.*
+
+interface CustomFilterService {
+    fun getUserCustomFilter(userId : UUID) : List<SelectCustomFilter>
+
+    fun updateUserCustomFilter(userId : UUID, updateCustomFilter: UpdateCustomFilter)
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
@@ -8,6 +8,9 @@ import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.S
 import com.tinuproject.tinu.domain.customfilter.repository.CustomFilterRepository
 import com.tinuproject.tinu.domain.entity.CustomCategory
 import com.tinuproject.tinu.domain.entity.CustomFilter
+import com.tinuproject.tinu.domain.exception.common.NotFoundException
+import com.tinuproject.tinu.domain.exception.common.UnauthorizedAccessException
+import com.tinuproject.tinu.domain.exception.customfilter.NotExistCustomFilter
 import com.tinuproject.tinu.domain.exception.mail.NotExistMemberException
 import com.tinuproject.tinu.domain.member.repository.MemberRepository
 import org.springframework.stereotype.Service
@@ -76,7 +79,31 @@ class CustomFilterServiceImpl(
         }
     }
 
+    @Transactional
     override fun updateCustomFilter(userId: UUID, updateCustomFilter: UpdateCustomFilter) {
-        TODO("Not yet implemented")
+        val customFilter = customFilterRepository.findCustomFilterById(updateCustomFilter.filterId!!) ?: throw NotExistCustomFilter()
+
+        if(customFilter.member.userId!=userId){
+            throw UnauthorizedAccessException()
+        }
+
+        customFilter.updateCustomFilter(updateCustomFilter)
+
+        customCategoryRepository.deleteAllByCustomFilter(customFilter = customFilter)
+
+        customCategoryRepository.flush()
+
+        mappingCustomCategory(customFilter,updateCustomFilter.category)
+    }
+
+
+    private fun mappingCustomCategory(customFilter: CustomFilter, categorys : MutableList<Long>){
+        val categories = categoryRepository.findAllById(categorys)
+
+        val customCategories = categories.map { category ->
+            CustomCategory(category = category, customFilter = customFilter)
+        }
+
+        customCategoryRepository.saveAll(customCategories)
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
@@ -3,16 +3,18 @@ package com.tinuproject.tinu.domain.customfilter.service
 import com.tinuproject.tinu.domain.category.repository.CategoryRepository
 import com.tinuproject.tinu.domain.customcategory.repository.CustomCategoryRepository
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.CreateCustomFilter
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.DeleteCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.SelectCustomFilter
 import com.tinuproject.tinu.domain.customfilter.repository.CustomFilterRepository
 import com.tinuproject.tinu.domain.entity.CustomCategory
 import com.tinuproject.tinu.domain.entity.CustomFilter
-import com.tinuproject.tinu.domain.exception.common.NotFoundException
 import com.tinuproject.tinu.domain.exception.common.UnauthorizedAccessException
 import com.tinuproject.tinu.domain.exception.customfilter.NotExistCustomFilter
 import com.tinuproject.tinu.domain.exception.mail.NotExistMemberException
 import com.tinuproject.tinu.domain.member.repository.MemberRepository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -24,7 +26,7 @@ class CustomFilterServiceImpl(
     val customCategoryRepository: CustomCategoryRepository,
     val categoryRepository: CategoryRepository
 ):CustomFilterService {
-
+    val log :Logger = LoggerFactory.getLogger(this::class.java)
 
     @Transactional(readOnly = true)
     override fun getCustomFilter(userId: UUID): List<SelectCustomFilter> {
@@ -67,16 +69,7 @@ class CustomFilterServiceImpl(
         )
 
         customFilterRepository.save(customFilter)
-
-        for(i  in createCustomFilter.category){
-            val category = categoryRepository.findById(i).get()
-
-            val customCategory = CustomCategory(
-                category =  category,
-                customFilter = customFilter
-            )
-            customCategoryRepository.save(customCategory)
-        }
+        mappingCustomCategory(customFilter, createCustomFilter.category.toMutableList() )
     }
 
     @Transactional
@@ -88,22 +81,46 @@ class CustomFilterServiceImpl(
         }
 
         customFilter.updateCustomFilter(updateCustomFilter)
+        log.info("delete 실행.")
+        customCategoryRepository.deleteAllByCustomFilterId(customFilterId = customFilter.id!!)
+        mappingCustomCategory(customFilter,updateCustomFilter.category.toMutableList())
+    }
 
-        customCategoryRepository.deleteAllByCustomFilter(customFilter = customFilter)
+    @Transactional
+    override fun deleteCustomFilter(userId :UUID, deleteCustomFilter : DeleteCustomFilter){
+        val existCustomFilter = customFilterRepository.findCustomFilterById(deleteCustomFilter.filterId)?: throw NotExistCustomFilter()
 
-        customCategoryRepository.flush()
 
-        mappingCustomCategory(customFilter,updateCustomFilter.category)
+        if(existCustomFilter.member.userId != userId) throw UnauthorizedAccessException()
+        log.info("커스텀 필터 삭제")
+        customCategoryRepository.deleteAllByCustomFilterId(existCustomFilter.id!!)
+        customFilterRepository.deleteById(deleteCustomFilter.filterId)
+        customFilterRepository.flush()
+        log.info("커스텀 필터 삭제 완료")
+    
     }
 
 
-    private fun mappingCustomCategory(customFilter: CustomFilter, categorys : MutableList<Long>){
-        val categories = categoryRepository.findAllById(categorys)
+    private fun mappingCustomCategory(customFilter: CustomFilter, categorylist : MutableList<Long>){
+        val categories = categoryRepository.findAllById(categorylist)
 
         val customCategories = categories.map { category ->
             CustomCategory(category = category, customFilter = customFilter)
         }
 
         customCategoryRepository.saveAll(customCategories)
+    }
+
+    private fun garbageMappingCustomCategory(customFilter: CustomFilter, categorylist: MutableList<Long>){
+        for(i  in categorylist){
+            val category = categoryRepository.findById(i).get()
+
+            val customCategory = CustomCategory(
+                category = category,
+                customFilter = customFilter
+            )
+
+            customCategoryRepository.save(customCategory)
+        }
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
@@ -1,17 +1,30 @@
 package com.tinuproject.tinu.domain.customfilter.service
 
+import com.tinuproject.tinu.domain.category.repository.CategoryRepository
+import com.tinuproject.tinu.domain.customcategory.repository.CustomCategoryRepository
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.CreateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
 import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.SelectCustomFilter
 import com.tinuproject.tinu.domain.customfilter.repository.CustomFilterRepository
+import com.tinuproject.tinu.domain.entity.CustomCategory
+import com.tinuproject.tinu.domain.entity.CustomFilter
 import com.tinuproject.tinu.domain.exception.mail.NotExistMemberException
 import com.tinuproject.tinu.domain.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
+@Service
 class CustomFilterServiceImpl(
     val memberRepository: MemberRepository,
-    val customFilterRepository: CustomFilterRepository
+    val customFilterRepository: CustomFilterRepository,
+    val customCategoryRepository: CustomCategoryRepository,
+    val categoryRepository: CategoryRepository
 ):CustomFilterService {
-    override fun getUserCustomFilter(userId: UUID): List<SelectCustomFilter> {
+
+
+    @Transactional(readOnly = true)
+    override fun getCustomFilter(userId: UUID): List<SelectCustomFilter> {
         val result = mutableListOf<SelectCustomFilter>()
 
         val member = memberRepository.findMemberByUserId(userId = userId)?:throw NotExistMemberException()
@@ -22,7 +35,7 @@ class CustomFilterServiceImpl(
             val categorys = mutableListOf<Long>()
 
             for(category in customFilter.customCategory){
-                categorys.add(category.id!!)
+                categorys.add(category.category.id!!)
             }
 
             result.add(SelectCustomFilter(
@@ -38,7 +51,32 @@ class CustomFilterServiceImpl(
         return result
     }
 
-    override fun updateUserCustomFilter(userId: UUID, updateCustomFilter: UpdateCustomFilter) {
+    @Transactional
+    override fun createCustomFilter(userId: UUID, createCustomFilter: CreateCustomFilter) {
+        val member = memberRepository.findMemberByUserId(userId)?:throw NotExistMemberException()
+
+        val customFilter = CustomFilter(
+            filterName = createCustomFilter.filterName,
+            isSell = createCustomFilter.isSell,
+            maxPrice = createCustomFilter.maxPrice,
+            minPrice = createCustomFilter.minPrice,
+            member = member
+        )
+
+        customFilterRepository.save(customFilter)
+
+        for(i  in createCustomFilter.category){
+            val category = categoryRepository.findById(i).get()
+
+            val customCategory = CustomCategory(
+                category =  category,
+                customFilter = customFilter
+            )
+            customCategoryRepository.save(customCategory)
+        }
+    }
+
+    override fun updateCustomFilter(userId: UUID, updateCustomFilter: UpdateCustomFilter) {
         TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
@@ -48,7 +48,7 @@ class CustomFilterServiceImpl(
                 filterName =  customFilter.filterName,
                 maxPrice = customFilter.maxPrice,
                 minPrice = customFilter.minPrice,
-                isSell = customFilter.isSell,
+                onlySell = customFilter.onlySell,
                 category = categorys
             ))
         }
@@ -62,7 +62,7 @@ class CustomFilterServiceImpl(
 
         val customFilter = CustomFilter(
             filterName = createCustomFilter.filterName,
-            isSell = createCustomFilter.isSell,
+            onlySell = createCustomFilter.onlySell,
             maxPrice = createCustomFilter.maxPrice,
             minPrice = createCustomFilter.minPrice,
             member = member

--- a/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/customfilter/service/CustomFilterServiceImpl.kt
@@ -1,0 +1,44 @@
+package com.tinuproject.tinu.domain.customfilter.service
+
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.response.SelectCustomFilter
+import com.tinuproject.tinu.domain.customfilter.repository.CustomFilterRepository
+import com.tinuproject.tinu.domain.exception.mail.NotExistMemberException
+import com.tinuproject.tinu.domain.member.repository.MemberRepository
+import java.util.*
+
+class CustomFilterServiceImpl(
+    val memberRepository: MemberRepository,
+    val customFilterRepository: CustomFilterRepository
+):CustomFilterService {
+    override fun getUserCustomFilter(userId: UUID): List<SelectCustomFilter> {
+        val result = mutableListOf<SelectCustomFilter>()
+
+        val member = memberRepository.findMemberByUserId(userId = userId)?:throw NotExistMemberException()
+
+        val customFilters = member.customFilter
+
+        for(customFilter in customFilters){
+            val categorys = mutableListOf<Long>()
+
+            for(category in customFilter.customCategory){
+                categorys.add(category.id!!)
+            }
+
+            result.add(SelectCustomFilter(
+                filterId = customFilter.id!!,
+                filterName =  customFilter.filterName,
+                maxPrice = customFilter.maxPrice,
+                minPrice = customFilter.minPrice,
+                isSell = customFilter.isSell,
+                category = categorys
+            ))
+        }
+
+        return result
+    }
+
+    override fun updateUserCustomFilter(userId: UUID, updateCustomFilter: UpdateCustomFilter) {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/entity/CustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/entity/CustomFilter.kt
@@ -1,6 +1,7 @@
 package com.tinuproject.tinu.domain.entity
 
 
+import com.tinuproject.tinu.domain.customfilter.dto.client_controller.request.UpdateCustomFilter
 import com.tinuproject.tinu.domain.entity.base.BaseEntity
 import jakarta.persistence.*
 
@@ -25,4 +26,12 @@ class CustomFilter (
 
     @OneToMany(mappedBy = "customFilter", cascade = [CascadeType.REMOVE], fetch = FetchType.LAZY)
     var customCategory: MutableList<CustomCategory> = mutableListOf()
-) : BaseEntity()
+) : BaseEntity(){
+
+    fun updateCustomFilter(updateCustomFilter: UpdateCustomFilter){
+        this.filterName = updateCustomFilter.filterName
+        this.isSell = updateCustomFilter.isSell
+        this.maxPrice = updateCustomFilter.maxPrice
+        this.minPrice = updateCustomFilter.minPrice
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/entity/CustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/entity/CustomFilter.kt
@@ -18,7 +18,7 @@ class CustomFilter (
     var minPrice :Int?,
 
     @Column
-    var isSell : Boolean?,
+    var onlySell : Boolean?,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id")
@@ -30,7 +30,7 @@ class CustomFilter (
 
     fun updateCustomFilter(updateCustomFilter: UpdateCustomFilter){
         this.filterName = updateCustomFilter.filterName
-        this.isSell = updateCustomFilter.isSell
+        this.onlySell = updateCustomFilter.onlySell
         this.maxPrice = updateCustomFilter.maxPrice
         this.minPrice = updateCustomFilter.minPrice
     }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/exception/base/ErrorCode.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/exception/base/ErrorCode.kt
@@ -11,10 +11,10 @@ enum class ErrorCode(
 
 
     //멤버 관련
-    MEMBER_EXIST_EMAIL(httpStatusCode = 400, stateCode="ALREADY_EXIST_EMAIL", message = "이미 사용중인 이메일입니다."),
-    MEMBER_EXIST_NICKNAME(httpStatusCode = 400, stateCode = "ALREADY_EXIST_NICKNAME", message = "이미 사용중인 닉네임입니다."),
-    MEMBER_NOT_EXIST(httpStatusCode = 400, stateCode = "NOT_FOUND_MEMBER", message = "요청하신 이용자는 없는 이용자입니다."),
-    MEMBER_EXIST(httpStatusCode = 400, stateCode = "ALREADY_EXIST_MEMBER", message = "이미 회원가입이 진행된 계정입니다."),
+    MEMBER_EXIST_EMAIL(httpStatusCode = 409, stateCode="ALREADY_EXIST_EMAIL", message = "이미 사용중인 이메일입니다."),
+    MEMBER_EXIST_NICKNAME(httpStatusCode = 409, stateCode = "ALREADY_EXIST_NICKNAME", message = "이미 사용중인 닉네임입니다."),
+    MEMBER_NOT_EXIST(httpStatusCode = 404, stateCode = "NOT_FOUND_MEMBER", message = "요청하신 이용자는 없는 이용자입니다."),
+    MEMBER_EXIST(httpStatusCode = 409, stateCode = "ALREADY_EXIST_MEMBER", message = "이미 회원가입이 진행된 계정입니다."),
 
     //회원가입 - 이메일 인증
     UNIVERSITY_NOT_EXIST_DOMAIN(httpStatusCode = 400, stateCode = "NOT_EXIST_DOMAIN", message = "현재 서비스를 지원하는 학교가 아닌 것 같습니다."),
@@ -22,8 +22,10 @@ enum class ErrorCode(
     NOT_MATCH_CODE(httpStatusCode = 400, stateCode = "NOT_MATCH_CODE", message = "인증 코드가 일치하지 않습니다."),
     NEED_EMAIL_AUTH(httpStatusCode = 400, stateCode = "NEED_EMAIL_AUTH", message = "이메일 인증이 필요합니다."),
 
+    //커스텀 필터
+    FILTER_NOT_EXIST(httpStatusCode = 404, stateCode = "NOT_EXIST_FILTER", message = "요청하신 커스텀 필터를 찾을 수 없습니다."),
 
     //전역적 사용
     NOT_FOUND(httpStatusCode = 404, stateCode = "NOT_FOUND", message = "없는 페이지입니다."),
-    UNAUTHORIZED_ACCESS(httpStatusCode = 400, stateCode = "NOT_ACCESS", message = "잘못된 접근이 감지되었습니다.");
+    UNAUTHORIZED_ACCESS(httpStatusCode = 403, stateCode = "FORBIDDEN", message = "요청에 대한 권한이 없습니다.");
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/exception/customfilter/NotExistCustomFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/exception/customfilter/NotExistCustomFilter.kt
@@ -1,0 +1,7 @@
+package com.tinuproject.tinu.domain.exception.customfilter
+
+import com.tinuproject.tinu.domain.exception.base.BaseException
+import com.tinuproject.tinu.domain.exception.base.ErrorCode
+
+class NotExistCustomFilter():BaseException(ErrorCode.FILTER_NOT_EXIST) {
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #119 

## ✅ 작업 내용
커스텀 필터과 관련한 단순한 로직들에 대한 구현을 실시하였습니다.

- [x] 커스텀 필터 생성 로직 구현
- [x] 커스텀 필터 삭제 로직 구현
- [x] 커스텀 필터 수정 로직 구현
- [x] 커스텀 필터 조회 로직 구현
- [x] 커스텀 필터과 관련된 카테고리, 커스텀 카테고리 로직 구현.

### 1️⃣ PR 핵심 내용
<hr>

단순 작업이라 작업 내용 자체에는 크게 서술할 내용이 없습니다.

그러나 연관 관계 처리가 있는 (Member-CustomFilter-CustomCategory-Category) 로직을 처리 한만큼 
각 연관 관계들을 관리해주는 일에 대해 많은 신경을 써주어야합니다.
</br>

 ### 이번에는 DB적인 측면에서 주로 다루어보겠습니다.
 
연관관계가 설정되어있는 Entity를 다룰 때 주의해야할 것은 개발자가 의도한 것보다 불필요하게 많은 DB 접근을 하게 되는 것입니다.

가장 유명한 내용으로 **N+1 문제**  를 들어보셨을 겁니다.

N+1 을 간단하게 서술하면
**문제 발생 원인 :** 연관관계 설정이 되어있는 A Entity와 B Entity 여럿(1개 이상(n))이 존재할 때 A Entity를 조회할 때 발생

**문제 상황 :** 개발자는 A Entity만을 조회하고 싶었는데 그와 관련한 n 개의 B Entity의 조회도 이루어지는 상황입니다.
_N + 1이라고 적는다고 N개에 한개가 더해진다가 아닌 1개에 N개의 쿼리가 더해진다 입니다. 저는 이거 헷갈려했었어요._ 

**해결 방안 :** 흔한 해결 방안이 Fatch.Lazy 설정을 해주는 것입니다. 이와 관련해서는 저희 프로젝트에도 적용되어 있어요!.


### 2️⃣ Jpa 기본 메서드들을 잘 숙지하기
<hr>
Spring Boot Jpa 속 Repository Interface를 사용해보면 자신이 원하는 쿼리를 쉽게 작성할 수 있는 것처럼 느껴집니다.
기본적으로 조회나 삭제, 생성과 관련한 메소드를 별도로 정의해주지 않아도 이미 생성되어 있기도 합니다.
</br></br>

![image](https://github.com/user-attachments/assets/8952968c-6730-4865-a10c-61252bba71fd)

</br>
저희들의 Repository 코드에서 따로 구현하지 메소드들이 있는 것을 확인해볼 수 있죠

이 때 해당 메소드들이 어떻게 작동을 하는 지를 잘 구분해두지 않으면 이 후 서비스 로직을 구현할 때 불필요한 DB 접근을 겪게 되는 경우가 있을 수 있습니다.

실제 프로젝트에서의 예시입니다.

**문제의 코드 :** </br>
![1  create에서 customCatgory의 DB 접근 수 문제 해결 전](https://github.com/user-attachments/assets/685491ff-4341-4d97-ae42-299759b5c635)

해당 코드는 </br>
![image](https://github.com/user-attachments/assets/e5e76393-1836-44a5-b167-67cc3eb5f78d)

와 같은 CustomFilter create 서비스에 접근할 때 CustomFilter 와 연관관계를 맺는 Category를 추가해주는 로직입니다.
RequestBody에서 넘겨준 Category List의 ID로부터 DB에서 Category 찾아 각각 CustomCategory를 만들어주는 것입니다.

이때 여기까지만 읽어보고 혹시 어떤 문제가 발생할 수 있을 지 감이 잡히시나요?

 해당 문제는 개발자가 설계한 알고리즘 단계부터 잘못되어 의도치 않게 DB 접근이 많아지는 경우입니다.
 또한 제가 실제로 의식의 흐름대로 코드를 작성하다보니 겪은 문제기두 하구요.</br>
 
 **문제의 원인**
![image](https://github.com/user-attachments/assets/ad5740e6-a7b3-4819-93c9-fbbf01a1f8ff)
코드에 따르면 **Category Id의 수**만큼 DB에 접근해 Category를 가져오고 CustomCategory를 만들고를 반복합니다.

즉 Category가 N개라면 N개의 DB 접근이 일어나게 되는겁니다. 거기에 CustomCategory를 Insert하는 SQL도 실행이 되어야할테니 적어도 2N의 DB 접근이 일어나게 되죠.

실제 로그를 확인해보면</br>
![image](https://github.com/user-attachments/assets/6ff98cd4-428a-4e92-89c7-52f2e45b37be) </br>
하나의 Insert마다 하나의 Select가 일어남을 확인할 수 있습니다.

**문제의 해결**
그럼 해당 문제를 어떻게 해결하는데? 라고 생각하실 수 있습니다.  
Jpa를 처음 다루거나 막연하게 사용해보았다면 아예 방법이 없어 보이기두 합니다.
그래서 Jpa말고 NativeQuery로 다운그레이드하거나 @Query로 따로 Query문을 작성해주거나 QueryDSL로 업그레이드 시켜야하나?
싶을 수도 있겠지만 Jpa에는 ~~All 이라는 자동 생성 목록에 뜨는 것이 존재합니다.(이후 '예약어'로 표현)

이는 SQL의 결과로 넘어온 튜플들을 Entity에 매칭하여 List 형식으로 반환해주게 됩니다.

![3  create에서 customCatgory의 DB 접근 수 문제 해결 후 코드](https://github.com/user-attachments/assets/dc974596-bb1c-4371-8813-840e3758d5b3)

코드에는 생략되어있긴하지만 categoryList가 List<Long>의 형태로 저장된 RequestBody로 넘어온 Category Id라고 생각해주세요.

이렇게 되면 where 절이 id = id 가 아닌 id in (categoryList) 형식으로 SQL을 실행시켜 한번의 쿼리로 여러 Category를 받아올 수 있습니다.
![4  create에서 customCatgory의 DB 접근 수 문제 해결 후 쿼리 수](https://github.com/user-attachments/assets/c9d49cb7-9a88-454c-b944-ee5affbc9d74)

실제 로그가 위와 같고

이전과 비교를 해보았을 때 Select가 n번에서 1번으로 줄어든 것을 확인해볼 수 있습니다. 

**이렇게 Jpa의 기본 제공 기능들만 잘 숙지해도 DB 성능적 상향이 일어날 수 있습니다.**
</br></br>

### 3️⃣ JPA 작동 방식 숙지하기
<hr>
위 내용만 본다면 Jpa의 기본 기능들만 잘 숙지하더라도 DB 접근과 관련한 문제들을 해결할 수 있을 것 같습니다.

실제 대부분의 상황에서 이를 숙지해준다면 어느 정도의 DB 최적화는 보장되기는 합니다.
예외적인 부분이 **생명주기를 같이하는 연관관계 매핑이 있는 경우**가 있습니다._물론 다른 예외상황도 많음_

 이때 생명주기를 같이하는 연관관계 매핑 예시로는 CaseCade Remove 같은 것입니다.
casecade remove가 문제가 되는 경우는 delete가 일어날 때입니다.

**문제의 코드**</br> 
![1  delete 쿼리 문제점 코드](https://github.com/user-attachments/assets/b64f7df0-cdb6-4d50-9c2b-90be248d396d) </br>

deleteById라니 마치 CustomFilter를 삭제하고 그와 생명주기를 같이하는 CustomCategory도 한번에 싹 날려줄 것 같습니다.
실제 DB 시간에 cascade 설정이 되어 있는 경우 A를 삭제하면 A와 관련된 B를 다 삭제되는 경험을 해보셨다면
CustomFilter만 삭제해주면 별도의 DB 접근 없이도 DB가 알아서 CustomCategory도 삭제해줄 것이라 생각할 수 있습니다.

이는 DB와 JPA를 구분하지 못하여 발생한 오류입니다. 
JPA를 사용하면 SQL 쿼리문을 작성 안해도되고, 알아서 DB에 접근도 해주니 DB와 연결되어 있는 존재라고 생각이 들 수 있습니다.
하지만 JPA는 ORM(Object-Relation Mapping)으로 DB와 자바(객체)를 연결해주는 연결책입니다.
음.. 자바에서 관계형DB의 데이터들을 객체로 다룰 수 있도록 도와주는 존재가 더 이해하기 쉬운 표현일것 같습니다.

그런 의미에서 우리가 Entity 객체에 작성해주는 cascade는 DB 상의 cascade가 아닌 ORM 상의 cascade를 의미합니다.

이때 ORM이 객체를 관리해주기 위해서는 영속성 컨텍스트에 해당 객체를 끌고 와야한다는 점을 인식하여야합니다.

이를 염두하고 CustomFilter를 지우는 로직이 진행된다구 해봅시다.

ORM에서 해당 CustomFilter를 지우기 위해서는 해당 CustomFilter의 연관 객체들을 영속성 컨텍스트에 가져오는 과정이 필요합니다.

해당 과정은 DB에 연관된 객체들의 Select 문으로 불러오는 것으로 진행됩니다.

실제 로그를 확인해보면 

![2  delete 쿼리 문제점 로그](https://github.com/user-attachments/assets/bf899623-a5fc-4b8e-8d1c-073be1fad911)

(CustomFilter 1개에 4개의 CustomCategory 인 상황.)
CustomFilter와 연관된 CustomCategory 4개를 1회의 쿼리로 가져오는 것을 볼 수 있습니다.

그후엔 DB가 알아서 삭제해주는 것이 아닌 Jpa에서 CustomCategory를 삭제하기 위한 4개의 쿼리가 추가로 발생합니다.

그러고 나서 CustomFilter 삭제 쿼리 1개가 발생합니다.

게다가 뜬금없이 CustomCategory와 연관된 Category를 각각 Select해오는 4개의 쿼리까지

즉 4개의 CustomCategory와 연관을 맺은 CustomFilter의 삭제에는 10번의 DB 접근이 일어납니다.
   - CustomCategoryList Select 1개
   - category select 4개
   - CustomCategory delete 4개
   - CustomFilter delete 1개
 
 CustomFilter와 연관된 CustomCategory가 n개면 2n개의 쿼리가 추가 발생하는 끔찍한 결과를 맞이하게 됩니다.
 
 이때 뜬금없이 Category를 조회한 이유는
 CustomCategory와 연관이 있는 Category를 보고 삭제를 해야하기 떄문입니다.
 
**해결방안...?** 
<hr>

 '아하 Jpa에서 순차적으로 진행시키지 않고 CustomCategory를 한번에 삭제시킨 후 CustomFilter를 삭제시키면 쿼리 수가 감소하겠지?  이 때 2번에서 보았듯이 Jpa의 기본 기능 ~All~을 활용하여 delete 해주면 최적의 퀴리가 진행되겠다!'하고 

![image](https://github.com/user-attachments/assets/a631ec13-77ec-4552-a452-5dc82a20161b)

CustomCategoryRepository에 dellteAllByCustomFilter(customFilter : CustomFilter)를 선언해 호출해보면
</br>

기대와는 다르게 

![image](https://github.com/user-attachments/assets/201e5f72-9f30-4742-ae58-e77f94a9c389)

쿼리 수는 줄어들기는 커녕 CustomFilter를 조회하는 SQL 쿼리1회가 증가했습니다. 

JPA와 ORM 추가로 DB Lock에대해 익숙하지 않아 발생하는 문제입니다.

Spring MVC는 blocking i/o 를 보장하지만 동시성, 데이터 무결성까지는 보장하지 않습니다.
이유는 Spring이 멀티 쓰레드 방식을 지원하고,  db lock이 걸리지 않는 이상 다른 쓰레드에서 해당 DB에 대한 수정이 발생할 수 있게되기떄문입니다.


![image](https://github.com/user-attachments/assets/1dced628-be87-49cd-b691-15123f0767c6)

해당 코드에서 

existCustomFilter를 find 해오는 시점과, 

deleteAllByCustomFIlter() 가 실행되는 시점 중간 다른 스레드에서 해당 객체의 변환이 발생 할 수 있으니

CustomFilter를 한번 더 불러와 상태를 확인해보는 것입니다.

한번 더 불러오는 쿼리가 발생하는 것도 서러운데
CustomCategory와 연관된 Category 조회 쿼리도
CustomCategory를 삭제하는 쿼리도 전혀 줄어들지 않았습니다.

해당 내용이 줄어들지 않은 이유는 위에 서술한 내용과 마찬가지이기에 넘어가겠습니다.

그럼 어떻게 해야할까요...

**해결방안**
위의 경우들에는 두 가지 종류의 쿼리가 문제가 됩니다.

1. CustomCategory가 삭제되어도 Category에는 영향을 미치지 않는 데도 불구하고 이를 확인하기위해 Category들을 select.
![image](https://github.com/user-attachments/assets/1b7ab660-881d-42c2-9447-8f8522593d04)

2. CustomCategory를 삭제할 때 영속성으로 관리되고 있는 CustomCategory 하나하나씩 delete 하는 쿼리
![image](https://github.com/user-attachments/assets/02186e91-1f76-4e0d-ab8f-e66efc1e2523)

**그럼 이를 해결하기 위해서는 정말로 NativeQuery를 쓰거나 QueryDSL로 넘어가야하냐? 아닙니다.**

Jpa의 기본 기능만으로 해결 할 수 없을 때 사용하는 방법이 @Query 애너테이션을 사용하는 방식입니다.

@Query 애너테이션은 Repository의 메소드가 어떤 SQL문을 실행할지 개발자가 직접 적어준다고 생각하면 됩니다.

![image](https://github.com/user-attachments/assets/a3600d3d-4119-43e6-a40b-bd5028c3980c)

이와 같은 방식으로 사용되며, 이를 활용한 코드

![image](https://github.com/user-attachments/assets/4bb73b03-cce3-4514-8c1e-94f341b34d5e)

는 다음과 같은 카테고리 10개가 포함된 요청에도

![image](https://github.com/user-attachments/assets/b81de946-5b0f-4333-9d0f-a31cf629b32b)

단 3번의 DB 접근으로 끝남을 확인할 수 있습니다.

![image](https://github.com/user-attachments/assets/bfe64c5a-33bc-45d8-8562-ad50a7a51597)

해당 문제점의 해결을 통해 저는 
백엔드 개발자가 DB, 도메인에 대한 지식이 높아야하는 이유에 대해서 깨달을 수 있었습니다.

이번에도 백엔드 개발자가 CustomCategory를 삭제할 때 Category는 영향을 받지 않는다는 도메인 지식이 있어야 가능합니다.

@Query를 통해 해당 과정을 생략하며 DB의 접근을 줄이게 되는 것처럼 많은 기반 지식은 백엔드 개발자의 힘이 되는 것이 맞다라는 것으로 글을 마무리해보겠습니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

그렇다면 직접 쿼리문을 작성하는 @Query 방식은 SQL Injection으로부터 자유로울까요?

자유롭다면 어떻게 자유로운 것일까를 한번 찾아보면 좋을 것 같습니다.


## ✍ 궁금한 것
이후 테스트 해볼 내용으로 저희들의 DB는 별도의 Query문이 아닌 Spring Jpa가 create한 table들이라
DB 자체에 각 테이블 간의 CaseCade 설정이 별도로 되어 있지 않을 것이라고 예상하고 있습니다.

그럼 DB Create Table 문을 직접 작성하여 case cade를 걸어주고,
@Query로 직접 CustomFilter를 삭제하면 ORM CustomCategory를 조회하지 않고 DB가 삭제해줄 것 같은데 

해당 예상이 맞는 지를 테스트 해보겠습니다.