### PR TITLE
⭐ [Feature] : 단일 이미지 검증 로직 구현 - 150

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/s3/service/S3Service.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/s3/service/S3Service.kt
@@ -7,8 +7,10 @@ import com.tinuproject.tinu.s3.dto.response.S3PresignedUrlResponse
 interface S3Service {
     suspend fun getPreSignedUrl(s3PresignedUrlRequest: S3PresignedUrlRequest): S3PresignedUrlResponse
 
-    suspend fun verifyImage(objects: List<S3Verifiable>): List<String>
+    suspend fun verifyImages(objects: List<S3Verifiable>): List<String>
 
-    fun removeImage(objects: List<String>)
+    fun verifyImage(obj: S3Verifiable): String
+
+    fun removeImages(objects: List<String>)
 
 }

--- a/src/main/kotlin/com/tinuproject/tinu/s3/service/S3ServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/s3/service/S3ServiceImpl.kt
@@ -86,7 +86,7 @@ class S3ServiceImpl(
         private val ALLOWED_EXTENSIONS = listOf("image/jpg", "image/jpeg", "image/png", "image/webp")
     }
 
-    override suspend fun verifyImage(objects: List<S3Verifiable>): List<String> = withContext(Dispatchers.IO) {
+    override suspend fun verifyImages(objects: List<S3Verifiable>): List<String> = withContext(Dispatchers.IO) {
         val urls = objects.map { obj ->
             async {
                 val response: HeadObjectResponse
@@ -111,7 +111,26 @@ class S3ServiceImpl(
         urls
     }
 
-    override fun removeImage(objects: List<String>) {
+    override fun verifyImage(obj: S3Verifiable): String {
+        val response: HeadObjectResponse
+        try {
+            response = s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(obj.key)
+                    .build())
+        } catch (e: software.amazon.awssdk.services.s3.model.NoSuchKeyException) {
+            throw NoSuchKeyException()
+        }
+        log.info(response.eTag())
+        log.info(obj.ETag)
+        if (response.eTag().trim('"') != obj.ETag) {
+            throw InvalidETagException()
+        }
+
+        return "${cloudFrontDomain}/${obj.key}"
+    }
+
+    override fun removeImages(objects: List<String>) {
         val keys = objects.map { url ->
             url.removePrefix("${cloudFrontDomain}/")
         }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #133 

## ✅ 작업 내용

- [x] 단일 이미지 검증 로직 구현
- [x] 기존 이미지 로직 이름 수정

이미지 검증 로직은 여러 이미지를 비동기적으로 수행하기 위해 코루틴을 사용했었습니다.

그러나 채팅이나, 프로필 사진 등의 도메인에서 이미지 검증 로직을 활용함에 있어 다음과 같은 비효율적인 부분을 발견했습니다.
- 단일 이미지는 동기 로직으로도 충분하다는 점
- 단일 이미지를 List에 담아야 한다는 점
- 기존 비동기 로직을 사용하려면 suspend를 추가해야 된다는 점
에 의해서 단일 이미지 검증 로직을 새로 구현하였습니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
