### PR TITLE
유저 프로필 이미지 관련 로직 수정

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/domain/entity/Member.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/entity/Member.kt
@@ -3,6 +3,7 @@ package com.tinuproject.tinu.domain.entity
 import com.tinuproject.tinu.domain.entity.base.BaseEntity
 import com.tinuproject.tinu.domain.enums.Social
 import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO
+import com.tinuproject.tinu.domain.member.dto.controller_service.input.UpdateUserInputDTO
 import jakarta.persistence.*
 import java.util.*
 
@@ -76,11 +77,12 @@ class Member (
     var customFilter : MutableList<CustomFilter> = mutableListOf()
 ) : BaseEntity(){
 
-    fun updateMemberInfo(updateUserInfoRequestDTO: UpdateUserInfoRequestDTO){
-        this.nickname = updateUserInfoRequestDTO.nickname
-        this.grade = updateUserInfoRequestDTO.grade
-        this.major = updateUserInfoRequestDTO.major
-        this.introduction = updateUserInfoRequestDTO.introduction
+    fun updateMemberInfo(updateUserInputDTO: UpdateUserInputDTO){
+        this.nickname = updateUserInputDTO.nickname
+        this.grade = updateUserInputDTO.grade
+        this.major = updateUserInputDTO.major
+        this.introduction = updateUserInputDTO.introduction
+        this.profileImageURL = updateUserInputDTO.profile
     }
 
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/RegisterRequestDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/RegisterRequestDTO.kt
@@ -1,17 +1,14 @@
 package com.tinuproject.tinu.domain.member.dto.client_controller.request
 
-import com.tinuproject.tinu.s3.dto.S3Verifiable
+import com.tinuproject.tinu.s3.dto.request.S3VerifiableRequest
+
 
 data class RegisterRequestDTO(
     val nickName : String,
-    val profile : Image?,
+    val profile : S3VerifiableRequest?,
     val major : String,
     val grade : Int,
     val email : String,
     val introduction : String?,
 ){
-    data class Image (
-        override val key: String,
-        override val ETag: String
-    ):S3Verifiable
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/RegisterRequestDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/RegisterRequestDTO.kt
@@ -1,10 +1,17 @@
 package com.tinuproject.tinu.domain.member.dto.client_controller.request
 
+import com.tinuproject.tinu.s3.dto.S3Verifiable
+
 data class RegisterRequestDTO(
     val nickName : String,
-    val profileImageURL : String?,
+    val profile : Image?,
     val major : String,
     val grade : Int,
     val email : String,
-    val introduction : String?
-)
+    val introduction : String?,
+){
+    data class Image (
+        override val key: String,
+        override val ETag: String
+    ):S3Verifiable
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
@@ -1,7 +1,6 @@
 package com.tinuproject.tinu.domain.member.dto.client_controller.request
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.tinuproject.tinu.s3.dto.S3Verifiable
+import com.tinuproject.tinu.s3.dto.request.S3VerifiableRequest
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "유저 정보 업데이트")
@@ -15,14 +14,7 @@ data class UpdateUserInfoRequestDTO(
     @Schema(description = "학년", example = "3")
     val grade : Int,
     @Schema(description = "바꾸는 이미지")
-    val profile : Image?
+    val profile : S3VerifiableRequest?
 ) {
 
-    data class Image(
-        @Schema(description = "s3 이미지 Key", example = "Test")
-        override val key: String,
-
-        @Schema(description = "s3 이미지 등록시 받아지는 Tag", example = "TestETag")
-        override val ETag: String
-    ):S3Verifiable
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
@@ -1,19 +1,13 @@
 package com.tinuproject.tinu.domain.member.dto.client_controller.request
 
 import com.tinuproject.tinu.s3.dto.request.S3VerifiableRequest
-import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "유저 정보 업데이트")
+
 data class UpdateUserInfoRequestDTO(
-    @Schema(description = "닉네임", example = "김태완")
     val nickname : String,
-    @Schema(description = "자기소개", example = "안녕하세요! 항상 공정한 거래를 약속드립니다.")
     val introduction : String?,
-    @Schema(description = "전공", example = "중고거래학과")
     val major : String?,
-    @Schema(description = "학년", example = "3")
     val grade : Int,
-    @Schema(description = "바꾸는 이미지")
     val profile : S3VerifiableRequest?
 ) {
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
@@ -7,8 +7,6 @@ data class UpdateUserInfoRequestDTO(
     val nickname : String,
     val introduction : String?,
     val major : String?,
-    val grade : Int,
+    val grade : Int?,
     val profile : S3VerifiableRequest?
-) {
-
-}
+)

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/client_controller/request/UpdateUserInfoRequestDTO.kt
@@ -1,9 +1,28 @@
 package com.tinuproject.tinu.domain.member.dto.client_controller.request
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.tinuproject.tinu.s3.dto.S3Verifiable
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "유저 정보 업데이트")
 data class UpdateUserInfoRequestDTO(
+    @Schema(description = "닉네임", example = "김태완")
     val nickname : String,
+    @Schema(description = "자기소개", example = "안녕하세요! 항상 공정한 거래를 약속드립니다.")
     val introduction : String?,
+    @Schema(description = "전공", example = "중고거래학과")
     val major : String?,
-    val grade : Int
+    @Schema(description = "학년", example = "3")
+    val grade : Int,
+    @Schema(description = "바꾸는 이미지")
+    val profile : Image?
 ) {
+
+    data class Image(
+        @Schema(description = "s3 이미지 Key", example = "Test")
+        override val key: String,
+
+        @Schema(description = "s3 이미지 등록시 받아지는 Tag", example = "TestETag")
+        override val ETag: String
+    ):S3Verifiable
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/controller_service/input/UpdateUserInputDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/controller_service/input/UpdateUserInputDTO.kt
@@ -1,7 +1,6 @@
 package com.tinuproject.tinu.domain.member.dto.controller_service.input
 
 import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO
-import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO.Image
 import io.swagger.v3.oas.annotations.media.Schema
 
 class UpdateUserInputDTO(){

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/controller_service/input/UpdateUserInputDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/controller_service/input/UpdateUserInputDTO.kt
@@ -1,0 +1,21 @@
+package com.tinuproject.tinu.domain.member.dto.controller_service.input
+
+import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO
+import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO.Image
+import io.swagger.v3.oas.annotations.media.Schema
+
+class UpdateUserInputDTO(){
+    var nickname : String =""
+    var introduction : String? = null
+    var major : String? = null
+    var grade : Int = 4
+    var profile : String? = null
+
+    constructor(updateUserInfoRequestDTO: UpdateUserInfoRequestDTO, url : String?):this(){
+        this.nickname = updateUserInfoRequestDTO.nickname
+        this.grade = updateUserInfoRequestDTO.grade
+        this.introduction = updateUserInfoRequestDTO.introduction
+        this.major = updateUserInfoRequestDTO.major
+        this.profile = url
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/controller_service/input/UpdateUserInputDTO.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/dto/controller_service/input/UpdateUserInputDTO.kt
@@ -3,18 +3,10 @@ package com.tinuproject.tinu.domain.member.dto.controller_service.input
 import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO
 import io.swagger.v3.oas.annotations.media.Schema
 
-class UpdateUserInputDTO(){
-    var nickname : String =""
-    var introduction : String? = null
-    var major : String? = null
-    var grade : Int = 4
-    var profile : String? = null
-
-    constructor(updateUserInfoRequestDTO: UpdateUserInfoRequestDTO, url : String?):this(){
-        this.nickname = updateUserInfoRequestDTO.nickname
-        this.grade = updateUserInfoRequestDTO.grade
-        this.introduction = updateUserInfoRequestDTO.introduction
-        this.major = updateUserInfoRequestDTO.major
-        this.profile = url
-    }
+class UpdateUserInputDTO(updateUserInfoRequestDTO: UpdateUserInfoRequestDTO, url : String?){
+    var nickname : String = updateUserInfoRequestDTO.nickname
+    var introduction : String? = updateUserInfoRequestDTO.introduction
+    var major : String? = updateUserInfoRequestDTO.major
+    var grade : Int? = updateUserInfoRequestDTO.grade
+    var profile : String? = url
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/service/MemberServiceImpl.kt
@@ -120,7 +120,7 @@ class MemberServiceImpl(
 
         usableMemberByNickname(userId = userId, nickName = updateUserInfoRequestDTO.nickname)
 
-        var url = member.profileImageURL;
+        var url = member.profileImageURL
 
         updateUserInfoRequestDTO.profile?.let { url = s3Service.verifyImage(it) }
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/service/MemberServiceImpl.kt
@@ -10,9 +10,11 @@ import com.tinuproject.tinu.domain.exception.university.NotExistDomainException
 import com.tinuproject.tinu.domain.member.dto.client_controller.request.RegisterRequestDTO
 import com.tinuproject.tinu.domain.member.dto.client_controller.request.UpdateUserInfoRequestDTO
 import com.tinuproject.tinu.domain.member.dto.client_controller.response.MemberSearchResponseDTO
+import com.tinuproject.tinu.domain.member.dto.controller_service.input.UpdateUserInputDTO
 import com.tinuproject.tinu.domain.member.repository.MemberRepository
 import com.tinuproject.tinu.domain.socialmember.repository.SocialMemberRepository
 import com.tinuproject.tinu.domain.university.repository.UniversityRepository
+import com.tinuproject.tinu.s3.service.S3Service
 import com.tinuproject.tinu.web.email.entity.EmailAuth
 import com.tinuproject.tinu.web.email.repository.EmailRepository
 import org.slf4j.Logger
@@ -26,7 +28,8 @@ class MemberServiceImpl(
     val memberRepository: MemberRepository,
     val universityRepository: UniversityRepository,
     val emailAuthRepository: EmailRepository,
-    val socialMemberRepository: SocialMemberRepository
+    val socialMemberRepository: SocialMemberRepository,
+    val s3Service: S3Service
 ):MemberService {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -45,6 +48,15 @@ class MemberServiceImpl(
 
         university ?: throw NotExistDomainException()
 
+        
+        //회원 가입시 기본 url은 Null로
+        var url : String? = null
+        
+        //만약 이미지 입력이 있다면 해당 url을 입력
+        registerRequestDTO.profile?.let { url = s3Service.verifyImage(it) }
+
+
+
         val socialMember = socialMemberRepository.findByUserId(userId)
         val newMember = Member(
             userId = userId,
@@ -52,7 +64,7 @@ class MemberServiceImpl(
             nickname = registerRequestDTO.nickName,
             major = registerRequestDTO.major,
             grade = registerRequestDTO.grade,
-            profileImageURL = registerRequestDTO.profileImageURL,
+            profileImageURL = url,
             introduction = registerRequestDTO.introduction,
             email = registerRequestDTO.email,
             mark = 0.0,
@@ -108,7 +120,11 @@ class MemberServiceImpl(
 
         usableMemberByNickname(userId = userId, nickName = updateUserInfoRequestDTO.nickname)
 
-        member.updateMemberInfo(updateUserInfoRequestDTO)
+        var url = member.profileImageURL;
+
+        updateUserInfoRequestDTO.profile?.let { url = s3Service.verifyImage(it) }
+
+        member.updateMemberInfo(UpdateUserInputDTO(updateUserInfoRequestDTO, url))
 
         memberRepository.save(member)
 

--- a/src/main/kotlin/com/tinuproject/tinu/s3/dto/request/S3VerifiableRequest.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/s3/dto/request/S3VerifiableRequest.kt
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class S3VerifiableRequest (
     val key: String,
-    @get:JsonProperty("eTag")
+    @get:JsonProperty("ETag")
     val ETag: String
 )

--- a/src/main/kotlin/com/tinuproject/tinu/s3/dto/request/S3VerifiableRequest.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/s3/dto/request/S3VerifiableRequest.kt
@@ -1,6 +1,9 @@
 package com.tinuproject.tinu.s3.dto.request
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class S3VerifiableRequest (
     val key: String,
+    @get:JsonProperty("eTag")
     val ETag: String
 )


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #132 

## ✅ 작업 내용

- [x] 유저 신규 가입 시 프로필 이미지 받는 것을 Url 에서 eTag와 key로 변경
- [ ] 유저 정보 업데이트 시 프로필 이미지 받는 것을 URL에서 eTag와 key로 변경

### 해당 작업을 왜 했나요?

기존 Presigned Url과 관련하여 착각한 부분이 있었습니다.

기존의 이해했던 방식
-> presignedUrl 로 발급받은 url에 이미지를 저장하고, 다운로드 받는 것으로 이해.

실제 작동 방식
-> presignedUrl은 업로드할 때만 쓰이고, 그 이후 다운로드는 별개의 Url을 통해 동작.

**그로인한 문제점**
![image](https://github.com/user-attachments/assets/fd000bc0-be73-4ec7-b485-7e621c2d139b)
이미지 업로드가 끝난 시점 프론트가 가지고 있을 presignedUrl 을 저장하면 되는 줄 알고 
유저 신규 가입이나, 유저 프로필 갱신 시 프론트로부터 Url을 받음.

 -> 실제 프론트는 다운로드 받을 권한의 Url을 갖고 있지 않으며, S3관련 로직을 작성한 동헌씨의
 S3Service.verifyImage()를 통해 검증 이후 받아오는 로직을 사용해야했음.
 
 **그래서 뭐가 바뀌었나요?**
 유저 신규 가입이나, 업데이트 시 S3VerifiableRequest 클래스를 통해 이미지의 ETag와 Key를 받아와
![image](https://github.com/user-attachments/assets/881386d1-6745-4509-9076-aabae73ad665)

이를 S3Service.verifyimage() 메소드로 검증을 받은 이 후 결과 Url을 저장함.

![image](https://github.com/user-attachments/assets/0a795ed4-8f2d-45b1-b8c6-d0679472ee97)

**추가적인 변경 사항이 있나요**
**문제사항**
![image](https://github.com/user-attachments/assets/9c398f3c-92b4-4927-873d-f6b0b4ec92d5)
와 같이 data class를 RequestDto에 작성해두었더니 

[문제의 Swagger 화면]
![image](https://github.com/user-attachments/assets/a1da84a7-2505-40d6-bed0-b8f4e7941999)

S3Verifiable class의 ETag와 관련하여 eTag와 ETag 두가지로 표시되는 문제가 있었습니다.


이를 해결하기 위해 ETag 속성에 @get:JsonProperies() 를 추가해주었습니다.
![image](https://github.com/user-attachments/assets/51d24ae4-d552-4e46-b59a-a774f025c5e7)

그 결과 
![image](https://github.com/user-attachments/assets/9a97919f-d350-4bd3-be14-258878442b61)

처럼 정상적으로 되는 것을 확인할 수 있습니다.

## 리뷰 반영 사항
**보조 생성자 사용에서 주 생성자 위주로 변경**
코틀린의 생성자에 관한 이야기를 적다보니 코틀린은 주생성자를 위주로 코드가 쓰이길 원한다는 내용을 보았습니다.
그렇기에 
기존 보조 생성자를 활용하던 코드를 
![image](https://github.com/user-attachments/assets/c953a31b-87b7-4c5d-97c2-444ec9542d80)

주 생성자를 이용하게끔 수정하였습니다.
![image](https://github.com/user-attachments/assets/52613a54-3ea8-4589-a1e5-6a3b9f72fb69)

또한 코드를 수정하면서 Grade가 필수 값이 아니라는 것을 알게되어 Int에서 nullable한 타입인 Int?로 타입을 변경해주었습니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
