### PR TITLE
⭐ [Feature] : 회원가입 여부 확인 로직 추가 - 155

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/domain/token/refreshtoken/service/RefreshTokenServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/token/refreshtoken/service/RefreshTokenServiceImpl.kt
@@ -4,6 +4,7 @@ import com.tinuproject.tinu.domain.entity.RefreshToken
 import com.tinuproject.tinu.domain.exception.token.ExpiredTokenException
 import com.tinuproject.tinu.domain.exception.token.InvalidedTokenException
 import com.tinuproject.tinu.domain.exception.token.NotFoundTokenException
+import com.tinuproject.tinu.domain.member.repository.MemberRepository
 import com.tinuproject.tinu.domain.token.Tokens
 import com.tinuproject.tinu.domain.token.refreshtoken.repository.RefreshTokenRepository
 import com.tinuproject.tinu.security.jwt.JwtUtil
@@ -25,6 +26,7 @@ class RefreshTokenServiceImpl(
 
     private val refreshTokenRepository: RefreshTokenRepository,
     private val jwtUtil : JwtUtil,
+    private val memberRepository: MemberRepository
 ):RefreshTokenService {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -49,7 +51,7 @@ class RefreshTokenServiceImpl(
         refreshTokenRepository.save(newRefreshToken)
 
         //AccesToken 재발행.
-        val accessToken : String = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME)
+        val accessToken : String = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME,memberRepository.existsByUserId(userId = userId))
 
         return Tokens(accessToken=accessToken, refreshToken = refreshToken)
     }

--- a/src/main/kotlin/com/tinuproject/tinu/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/config/SecurityConfig.kt
@@ -105,7 +105,7 @@ class SecurityConfig(
             httpSecurity
                 .addFilterBefore(JwtTokenFilter(jwtUtil = jwtUtil, excludeUrls =allowedPaths), UsernamePasswordAuthenticationFilter::class.java)
                 .addFilterBefore(ExceptionHandlerFilter(objectMapper), JwtTokenFilter::class.java)
-                .addFilterAfter(SignUpFilter(jwtUtil=jwtUtil, excludeUrls =  allowedPaths, memberRepository = memberRepository), JwtTokenFilter::class.java)
+                .addFilterAfter(SignUpFilter(jwtUtil=jwtUtil, excludeUrls =  allowedPaths), JwtTokenFilter::class.java)
 
 
         return httpSecurity.build()

--- a/src/main/kotlin/com/tinuproject/tinu/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/config/SecurityConfig.kt
@@ -1,8 +1,10 @@
 package com.tinuproject.tinu.security.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.tinuproject.tinu.domain.member.repository.MemberRepository
 import com.tinuproject.tinu.security.filter.ExceptionHandlerFilter
 import com.tinuproject.tinu.security.filter.JwtTokenFilter
+import com.tinuproject.tinu.security.filter.SignUpFilter
 import com.tinuproject.tinu.security.jwt.JwtUtil
 import com.tinuproject.tinu.security.oauth2.handler.OAuthLoginFailureHandler
 import com.tinuproject.tinu.security.oauth2.handler.OAuthLoginSuccessHandler
@@ -34,7 +36,7 @@ class SecurityConfig(
     private val oauth2LoginSuccessHandler: OAuthLoginSuccessHandler,
     private val oAuthLoginFailureHandler: OAuthLoginFailureHandler,
     private val customOAuth2UserService: CustomOAuth2UserService,
-
+    private val memberRepository: MemberRepository,
     @Value("\${web.allowed-path}")
     private val allowedPaths : List<String>,
     private val objectMapper: ObjectMapper
@@ -64,7 +66,7 @@ class SecurityConfig(
 
     @Bean
     @Throws(Exception::class)
-    fun filterChain(httpSecurity: HttpSecurity): SecurityFilterChain {
+    fun filterChain(httpSecurity: HttpSecurity, memberRepository: MemberRepository): SecurityFilterChain {
         val sessionManagement = httpSecurity.httpBasic { obj: HttpBasicConfigurer<HttpSecurity> -> obj.disable() }
             //cors 설정
             .cors { corsConfigurer: CorsConfigurer<HttpSecurity?> ->
@@ -103,7 +105,7 @@ class SecurityConfig(
             httpSecurity
                 .addFilterBefore(JwtTokenFilter(jwtUtil = jwtUtil, excludeUrls =allowedPaths), UsernamePasswordAuthenticationFilter::class.java)
                 .addFilterBefore(ExceptionHandlerFilter(objectMapper), JwtTokenFilter::class.java)
-
+                .addFilterAfter(SignUpFilter(jwtUtil=jwtUtil, excludeUrls =  allowedPaths, memberRepository = memberRepository), JwtTokenFilter::class.java)
 
 
         return httpSecurity.build()

--- a/src/main/kotlin/com/tinuproject/tinu/security/filter/SignUpFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/filter/SignUpFilter.kt
@@ -9,7 +9,7 @@ import jakarta.servlet.http.HttpServletResponse
 import org.springframework.web.filter.OncePerRequestFilter
 
 class SignUpFilter(
-    private val memberRepository: MemberRepository,
+
     private val jwtUtil :JwtUtil,
 
     //토큰이 없어도 되는 api
@@ -25,9 +25,8 @@ class SignUpFilter(
     ) {
 
         var httpServeletRequest : HttpServletRequest = request
-        var accessToken : String
 
-        accessToken = jwtUtil.getTokenFromHeader(httpServeletRequest)
+        var accessToken : String = jwtUtil.getTokenFromHeader(httpServeletRequest)
 
         if(!jwtUtil.signCheck(accessToken)){
             throw NeedRegistException()

--- a/src/main/kotlin/com/tinuproject/tinu/security/filter/SignUpFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/filter/SignUpFilter.kt
@@ -1,0 +1,46 @@
+package com.tinuproject.tinu.security.filter
+
+import com.tinuproject.tinu.domain.exception.member.NeedRegistException
+import com.tinuproject.tinu.domain.member.repository.MemberRepository
+import com.tinuproject.tinu.security.jwt.JwtUtil
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.filter.OncePerRequestFilter
+
+class SignUpFilter(
+    private val memberRepository: MemberRepository,
+    private val jwtUtil :JwtUtil,
+
+    //토큰이 없어도 되는 api
+    private val excludeUrls : List<String>
+
+): OncePerRequestFilter(){
+
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+
+        var httpServeletRequest : HttpServletRequest = request
+        var accessToken : String
+
+        accessToken = jwtUtil.getTokenFromHeader(httpServeletRequest)
+
+        if(!jwtUtil.signCheck(accessToken)){
+            throw NeedRegistException()
+        }
+
+
+        filterChain.doFilter(request,response)
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+
+        return excludeUrls.stream().anyMatch {
+            request.servletPath.contains(it)
+        }||request.servletPath.contains("/api/register")
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/security/jwt/JwtUtil.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/jwt/JwtUtil.kt
@@ -38,8 +38,8 @@ class JwtUtil {
     fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign : Boolean): String {
         log.info("액세스 토큰 발행.")
         return Jwts.builder()
-            .claim("userId", uuid.toString())
-            .claim("isSign", isSign)// 클레임에 userId 추가
+            .claim("userId", uuid.toString())// 클레임에 userId 추가
+            .claim("isSign", isSign)// 클레임에 회원가입 여부 추가.
             .setIssuedAt(Date())
             .setExpiration(Date(System.currentTimeMillis() + expirationMillis))
             .signWith(getSigningKey())

--- a/src/main/kotlin/com/tinuproject/tinu/security/jwt/JwtUtil.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/jwt/JwtUtil.kt
@@ -35,10 +35,11 @@ class JwtUtil {
     }
 
     // 액세스 토큰을 발급하는 메서드
-    fun generateAccessToken(uuid: UUID, expirationMillis: Long): String {
+    fun generateAccessToken(uuid: UUID, expirationMillis: Long, isSign : Boolean): String {
         log.info("액세스 토큰 발행.")
         return Jwts.builder()
-            .claim("userId", uuid.toString()) // 클레임에 userId 추가
+            .claim("userId", uuid.toString())
+            .claim("isSign", isSign)// 클레임에 userId 추가
             .setIssuedAt(Date())
             .setExpiration(Date(System.currentTimeMillis() + expirationMillis))
             .signWith(getSigningKey())
@@ -124,16 +125,21 @@ class JwtUtil {
         }
     }
 
-    //토큰 속 유저와 실제 기대하는 user의 비교 검증
-    //ex : 글 수정 요청이 들어왔을때 실제 글쓴이와, 요구하는 Token 속 유저의 정보 비교
-    fun validateUserFromToken(token :String, expectedUserId : UUID){
-        validateToken(token);
-        if(!getUserIdFromToken(token).equals(expectedUserId.toString())){
-            //TODO(요청이 들어왔는데 해당 요청이 가능한 유저와 실제 요청 유저가 다를때 반환하는 에러로 처리)
-            //권한 없음
-            throw Exception()
+    fun signCheck(token : String) :Boolean{
+        return try {
+            getClaimsFromToken(token).get("isSign", Boolean::class.java)
+        } catch (e: JwtException) {
+            // 토큰이 유효하지 않은 경우
+            log.warn("유효하지 않은 토큰입니다.")
+            //(토큰이 유효하지 않는 경우 반환하는 Exception을 만들어 처리)
+            throw InvalidedTokenException()
+        } catch (e: IllegalArgumentException) {
+            log.warn("유효하지 않은 토큰입니다.")
+            //(토큰이 유효하지 않는 경우 반환하는 Exception을 만들어 처리)
+            throw InvalidedTokenException()
         }
     }
+
 
 
 }

--- a/src/main/kotlin/com/tinuproject/tinu/security/oauth2/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/security/oauth2/handler/OAuthLoginSuccessHandler.kt
@@ -72,7 +72,8 @@ class OAuthLoginSuccessHandler(
         refreshTokenRepository.save(newRefreshToken)
 
         // 액세스 토큰 발급
-        val accessToken: String = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME)
+        //Todo(이후 삭제 예정 - 로그인 진행 이후 별도의 재발급 요청으로 A.T를 받아올 수 밖에 없어서 안쓰는 로직이지만 테스트 간 A.T를 쉽게 구하기 위해 남겨둠.)
+        val accessToken: String = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME,true)
 
         val redirectUri = if(memberRepository.existsByUserId(userId)){
             String.format(REDIRECT_URL)


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #144 

## ✅ 작업 내용

- [x] JwtUtil에서 AccessToken에서 회원가입 여부 확인하는 메소드 추가
- [x] singup-check-filter 제작
- [x] AccessToken 생성 시 회원가입 여부 추가

### 1️⃣ 무엇을 작업했나요?
<hr>


**TINU-98 ⭐ [Feature] : 게시글 서비스 구현 PR** #137 

해당 PR을 진행하던 중, 유저가 회원가입을 완료한 상태인지 확인하는 로직이 부족하다는 점을 인지하게 되었습니다.

현재 시스템에서는 소셜 로그인 성공 시, OAuthLoginSuccessHandler를 통해
아직 회원가입을 하지 않은 유저를 {front-domain}/sign-up 페이지로 리다이렉트 시켜 회원가입을 진행하도록 하고 있습니다.

그러나 문제는, 소셜 로그인 이후 Access Token만 발급받은 뒤 직접 기본 페이지를 요청하는 경우에는
해당 유저가 회원가입을 완료한 유저인지 여부를 서버가 판단할 수 없다는 점입니다.

이러한 문제를 해결하기 위해, 기존 필터 체인에 '회원가입 완료 여부를 확인하는 필터'를 추가하였으며
이와 관련된 작업을 이번 PR에 처리하였습니다.


### 2️⃣ 어떤 작업을 수행했나요.
<hr>

작업한 내용은 위 체크리스트에서도 언급하였듯이


**1. AccessToken 생성 시 회원가입 여부 추가
2. JwtUtil에서 AccessToken에서 회원가입 여부 확인하는 메소드 추가
3. 회원 가입을 진행했는 지 확인하는 filter 제작**

 

### AccessToken 생성 시 회원가입 여부 추가
<hr>

해당 작업을 수행하기 위해, **Access Token 생성에 관여하는 RefreshTokenService에 MemberRepository를 주입하였습니다**.

Access Token을 생성할 때는 **memberRepository.existsByUserId(userId)**를 통해
해당 유저가 회원가입을 완료한 유저인지 여부를 확인하고, 이를 기반으로 토큰에 관련 정보를 포함시켰습니다.

RefreshTokenService에서의 실제 코드
```
val accessToken: String = jwtUtil.generateAccessToken(
    userId,
    memberRepository.existsByUserId(userId)
)
```

이 과정에서 **JwtUtil이 직접 memberRepository에 접근하여 회원가입 여부**를 확인하게 해도 되지 않느냐는 선택지가 있었지만,
**JwtUtil은 JWT 생성 및 파싱에 집중**하고, 그 외 책임은 최소화하고자 해당 방식을 택하지 않았습니다.

즉, **데이터베이스에 접근해야 하는 회원가입 여부 판단**은 **서비스 레이어의 책임으로 보고**,
JwtUtil은 토큰 생성 자체에만 관여하도록 책임을 분리한 것입니다.


### JwtUtil에서 AccessToken에서 회원가입 여부 확인하는 메소드 추가
<hr>

![image](https://github.com/user-attachments/assets/d53f870a-e040-4941-9c19-729b8a6914fb)

jwtToken에서 회원 가입 여부가 담긴 claim을 파싱하고 그 결과를 이후 서술할 Filter에서 사용하게 됩니다.

### 회원 가입을 진행했는 지 확인하는 filter 제작
<hr>

해당 필터의 코드는 간결하며, 다음과 같은 특징이 있습니다:

1. 회원가입 여부 확인
```
   if(!jwtUtil.signCheck(accessToken)){
            throw NeedRegistException()
        }
```
accessToken의 클레임에서 회원가입 여부를 확인하고, 가입이 되어있지 않으면 NeedRegistException을 발생시킵니다.


```
override fun shouldNotFilter(request: HttpServletRequest): Boolean {

        return excludeUrls.stream().anyMatch {
            request.servletPath.contains(it)
        }||request.servletPath.contains("/api/register")
    }
```
토큰 없이 접근 가능한 API들과 더불어, 회원가입을 하지 않은 상태에서도 접근이 가능해야 하는 /api/register 경로를 필터 제외 조건에 포함시켰습니다.


## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
