### PR TITLE
 [Fix] : jwtToken isSign 속성을 읽지 못하는 문제 해결 - 157

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/service/MemberServiceImpl.kt
@@ -110,9 +110,9 @@ class MemberServiceImpl(
     override fun findMemberByUserId(userId: UUID): MemberSearchResponseDTO {
         val member = memberRepository.findMemberByUserId(userId)
 
-        member?: NotExistMemberException()
+        member?: throw NotExistMemberException()
 
-        return MemberSearchResponseDTO(member!!)
+        return MemberSearchResponseDTO(member)
 
     }
 

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/JwtUtil.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/JwtUtil.kt
@@ -125,7 +125,10 @@ class JwtUtil {
 
     fun signCheck(token : String) :Boolean{
         return try {
-            getClaimsFromToken(token).get("isSign", Boolean::class.java)
+            val isSign : Boolean = getClaimsFromToken(token)["isSign"].toString().toBoolean()
+
+
+            isSign
         } catch (e: JwtException) {
             // 토큰이 유효하지 않은 경우
             log.warn("유효하지 않은 토큰입니다.")

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/JwtUtil.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/JwtUtil.kt
@@ -126,8 +126,6 @@ class JwtUtil {
     fun signCheck(token : String) :Boolean{
         return try {
             val isSign : Boolean = getClaimsFromToken(token)["isSign"].toString().toBoolean()
-
-
             isSign
         } catch (e: JwtException) {
             // 토큰이 유효하지 않은 경우

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/handler/OAuthLoginSuccessHandler.kt
@@ -61,11 +61,12 @@ class OAuthLoginSuccessHandler(
         val newRefreshToken = RefreshToken(userId = userId, token = refreshToken)
         refreshTokenRepository.save(newRefreshToken)
 
+        val existMember =memberRepository.existsByUserId(userId)
         // 액세스 토큰 발급
         //Todo(이후 삭제 예정 - 로그인 진행 이후 별도의 재발급 요청으로 A.T를 받아올 수 밖에 없어서 안쓰는 로직이지만 테스트 간 A.T를 쉽게 구하기 위해 남겨둠.)
-        val accessToken: String = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME,true)
+        val accessToken: String = jwtUtil.generateAccessToken(userId, ACCESS_TOKEN_EXPIRATION_TIME,existMember)
 
-        val redirectUri = if(memberRepository.existsByUserId(userId)){
+        val redirectUri = if(existMember){
             String.format(REDIRECT_URL)
         }else{
             String.format(SIGN_REDIRECT_URL)


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #150 

## ✅ 작업 내용

- [x] jwtUtil signCheck 메소드 수정
- [x] memberService throw 하지 않는 오류 수정


## 1️⃣ 무엇이 문제인가요?

### 문제상황

현재 코드 상 아래와 같이 isSign claim이 Boolean 타입으로 잘 들어가 있지만
![image](https://github.com/user-attachments/assets/b719d683-4857-41cf-b392-0b5cdcdf74ac)

```
fun signCheck(token : String) :Boolean{
        return try {
            getClaimsFromToken(token).get("isSign", Boolean::class.java)
        } catch (e: JwtException) {
            // 토큰이 유효하지 않은 경우
            log.warn("유효하지 않은 토큰입니다.")
            //(토큰이 유효하지 않는 경우 반환하는 Exception을 만들어 처리)
            throw InvalidedTokenException()
        } catch (e: IllegalArgumentException) {
            log.warn("유효하지 않은 토큰입니다.")
            //(토큰이 유효하지 않는 경우 반환하는 Exception을 만들어 처리)
            throw InvalidedTokenException()
        }
    }
```
을 통해서 값을 추출해낼 때 isSign이 Boolean 타입으로 역직렬화하지 못해
JwtException이 발생.

## 2️⃣ 어떻게 해결하였나요?

현재 isSign을 Boolean 타입으로 받아들이지 못하는 것이 문제를 야기시키는 것이기 때문에
isSign을 Boolean이 아닌 String으로 받고, 그것을 boolean 타입으로 변환 시키는 방식으로 변경하였습니다.
`
   val isSign : Boolean = getClaimsFromToken(token)["isSign"].toString().toBoolean()`

## 3️⃣ 그 외 변경 사항이 있나요?
첫번째는 MemberService에서 throw를 하지 않아 발생하는 이슈의 해결이 있고
![image](https://github.com/user-attachments/assets/16dc05e1-8ef3-45d2-9203-adf3722711bf)

두번째는
원래는 테스트 용이기에 소셜 로그인에 성공하면 jwtToken의 isSign 값을 항상 true로 하게끔 해두었었는데
이를 실제 처럼 회원가입이 완료된 회원만 true 가 되도록 수정했습니다.
![image](https://github.com/user-attachments/assets/1be80d90-3acd-49b0-b478-0d3b92542abd)


## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
