### PR TITLE
🔨 [Fix] : 판매글 조회 쿼리문 수정 - 158

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/PostController.kt
@@ -1,7 +1,6 @@
 package com.tinuproject.tinu.domain.post.controller
 
 import com.tinuproject.tinu.global.response.dto.ResponseDTO
-import com.tinuproject.tinu.domain.member.exception.NotExistMemberException
 import com.tinuproject.tinu.infra.s3.exception.InvalidETagException
 import com.tinuproject.tinu.infra.s3.exception.NoSuchKeyException
 import com.tinuproject.tinu.infra.s3.exception.UploadSizeOutOfRangeException
@@ -33,11 +32,6 @@ class PostController(
 ) {
     @GetMapping
     @Operation(summary = "게시글 목록 조회", description = "게시글 목록을 조회합니다.")
-    @SwaggerExceptionResponses(
-            exceptions = [
-                NotExistMemberException::class
-            ]
-    )
     fun getPosts(
             @AuthenticationPrincipal userId: UUID,
             @RequestParam(required = false) cursorId: String?,
@@ -62,7 +56,6 @@ class PostController(
     @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보를 조회합니다.")
     @SwaggerExceptionResponses(
             exceptions = [
-                NotExistMemberException::class,
                 PostNotFoundException::class,
                 UniversityNotMatchException::class,
                 PostHiddenException::class
@@ -79,8 +72,8 @@ class PostController(
     @Operation(summary = "게시글 생성", description = "게시글을 생성합니다.")
     @SwaggerExceptionResponses(
             exceptions = [
-                NotExistMemberException::class,
                 CategoryNotFoundException::class,
+                UploadSizeOutOfRangeException::class,
                 NoSuchKeyException::class,
                 InvalidETagException::class
             ]
@@ -133,7 +126,6 @@ class PostController(
     @Operation(summary = "게시글 스크랩", description = "게시글을 스크랩합니다.")
     @SwaggerExceptionResponses(
             exceptions = [
-                NotExistMemberException::class,
                 PostNotFoundException::class,
                 UniversityNotMatchException::class,
                 ScrapAlreadyExistException::class
@@ -151,7 +143,6 @@ class PostController(
     @Operation(summary = "게시글 스크랩 해제", description = "게시글 스크랩을 해제합니다.")
     @SwaggerExceptionResponses(
             exceptions = [
-                NotExistMemberException::class,
                 ScrapNotFoundException::class
             ]
     )

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepository.kt
@@ -1,7 +1,7 @@
 package com.tinuproject.tinu.domain.post.repository
 
 import com.querydsl.core.types.dsl.BooleanExpression
-import com.tinuproject.tinu.domain.post.entity.Post
+import com.tinuproject.tinu.domain.post.controller.dto.response.PostListBodyResponse
 import com.tinuproject.tinu.domain.university.entity.University
 
 interface PostQueryRepository {
@@ -14,7 +14,7 @@ interface PostQueryRepository {
         minPrice: Int?,
         maxPrice: Int?,
         onlySell: Boolean
-    ): List<Post>
+    ): List<PostListBodyResponse>
 
     fun customCursor(cursorId: String?): BooleanExpression?
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
@@ -35,7 +35,8 @@ class PostQueryRepositoryImpl(
                         post.thumbnail,
                         ConstantImpl.create(false),
                         post.scrapCount,
-                        post.isSell)
+                        post.isSell
+                    )
                 )
                 .from(post)
                 .where(
@@ -54,10 +55,10 @@ class PostQueryRepositoryImpl(
     }
 
     override fun customCursor(cursorId: String?): BooleanExpression? {
-        if (cursorId.isNullOrBlank()) {
-            return null
+        return when {
+            cursorId.isNullOrBlank() -> null
+            else -> post.id.lt(cursorId.toLong())
         }
-        return post.id.lt(cursorId.toLong())
     }
 
     override fun containsTitle(keyword: String?): BooleanExpression? {

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
@@ -49,15 +49,15 @@ class PostQueryRepositoryImpl(
 
     override fun containsTitle(keyword: String?): BooleanExpression? {
         return when {
-            keyword.isNullOrBlank() -> post.title.contains(keyword)
-            else -> null
+            keyword.isNullOrBlank() -> null
+            else -> post.title.contains(keyword)
         }
     }
 
     override fun containsBody(keyword: String?): BooleanExpression? {
         return when {
-            keyword.isNullOrBlank() -> post.body.contains(keyword)
-            else -> null
+            keyword.isNullOrBlank() -> null
+            else -> post.body.contains(keyword)
         }
     }
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.tinuproject.tinu.domain.post.repository
 
+import com.querydsl.core.types.ConstantImpl
+import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.tinuproject.tinu.domain.post.entity.Post
+import com.tinuproject.tinu.domain.post.controller.dto.response.PostListBodyResponse
 import com.tinuproject.tinu.domain.university.entity.University
 import com.tinuproject.tinu.domain.post.entity.QPost
 import org.springframework.stereotype.Repository
@@ -22,12 +24,20 @@ class PostQueryRepositoryImpl(
         minPrice: Int?,
         maxPrice: Int?,
         onlySell: Boolean
-    ): List<Post> {
+    ): List<PostListBodyResponse> {
         return queryFactory
-                .selectFrom(post)
-                .join(post.category).fetchJoin()
-                .join(post.author).fetchJoin()
-                .distinct()
+                .select(
+                    Projections.constructor(PostListBodyResponse::class.java,
+                        post.id,
+                        post.createdAt,
+                        post.title,
+                        post.price,
+                        post.thumbnail,
+                        ConstantImpl.create(false),
+                        post.scrapCount,
+                        post.isSell)
+                )
+                .from(post)
                 .where(
                         post.university.eq(university),
                         post.isHide.eq(false),

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
@@ -25,6 +25,9 @@ class PostQueryRepositoryImpl(
     ): List<Post> {
         return queryFactory
                 .selectFrom(post)
+                .join(post.category).fetchJoin()
+                .join(post.author).fetchJoin()
+                .distinct()
                 .where(
                         post.university.eq(university),
                         post.isHide.eq(false),

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostRepository.kt
@@ -4,5 +4,5 @@ import com.tinuproject.tinu.domain.post.entity.Post
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface PostRepository: JpaRepository<Post, Long> {
-    fun findPostById(id: Long): Post?
+    fun findPostById(postId: Long): Post?
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/ScrapRepository.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/ScrapRepository.kt
@@ -2,7 +2,12 @@ package com.tinuproject.tinu.domain.post.repository
 
 import com.tinuproject.tinu.domain.post.entity.Scrap
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ScrapRepository: JpaRepository<Scrap, Long> {
-    fun findScrapByMemberIdAndPostId(memberId: Long, postId: Long): Scrap?
+    @Query("SELECT s.post.id FROM Scrap s WHERE s.member.id = :memberId")
+    fun findPostIdsByMemberId(@Param("memberId") memberId: Long): Set<Long>
+
+    fun findScrapByMemberIdAndPostId(userId: Long, postId: Long): Scrap?
 }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostServiceImpl.kt
@@ -1,7 +1,6 @@
 package com.tinuproject.tinu.domain.post.service
 
 import com.tinuproject.tinu.domain.post.repository.CategoryRepository
-import com.tinuproject.tinu.domain.member.exception.NotExistMemberException
 import com.tinuproject.tinu.infra.s3.exception.UploadSizeOutOfRangeException
 import com.tinuproject.tinu.domain.post.exception.ScrapAlreadyExistException
 import com.tinuproject.tinu.domain.post.exception.ScrapNotFoundException
@@ -54,8 +53,7 @@ class PostServiceImpl(
             maxPrice: Int?,
             onlySell: Boolean
     ): PostsListResponse {
-        val member = memberRepository.findMemberByUserId(userId)
-                ?: throw NotExistMemberException()
+        val member = memberRepository.findMemberByUserId(userId)!!
 
         val university = member.university!!
 
@@ -103,8 +101,7 @@ class PostServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getPostDetail(userId: UUID, postId: Long): PostDetailResponse {
-        val member = memberRepository.findMemberByUserId(userId)
-                ?: throw NotExistMemberException()
+        val member = memberRepository.findMemberByUserId(userId)!!
 
         val post = postRepository.findPostById(postId)
                 ?: throw PostNotFoundException()
@@ -145,8 +142,7 @@ class PostServiceImpl(
 
     @Transactional
     override fun createPost(userId: UUID, postCreateRequest: PostCreateRequest): PostCreateResponse {
-        val member = memberRepository.findMemberByUserId(userId)
-                ?: throw NotExistMemberException()
+        val member = memberRepository.findMemberByUserId(userId)!!
 
         val category = categoryRepository.findCategoryById(postCreateRequest.categoryId)
                 ?: throw CategoryNotFoundException()
@@ -287,8 +283,7 @@ class PostServiceImpl(
 
     @Transactional
     override fun createPostScrap(userId: UUID, postId: Long) {
-        val member = memberRepository.findMemberByUserId(userId)
-                ?: throw NotExistMemberException()
+        val member = memberRepository.findMemberByUserId(userId)!!
 
         val post = postRepository.findPostById(postId)
                 ?: throw PostNotFoundException()
@@ -308,8 +303,7 @@ class PostServiceImpl(
 
     @Transactional
     override fun deletePostScrap(userId: UUID, postId: Long) {
-        val member = memberRepository.findMemberByUserId(userId)
-                ?: throw NotExistMemberException()
+        val member = memberRepository.findMemberByUserId(userId)!!
 
         val scrap = scrapRepository.findScrapByMemberIdAndPostId(member.id!!, postId)
                 ?: throw ScrapNotFoundException()

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostServiceImpl.kt
@@ -79,16 +79,18 @@ class PostServiceImpl(
             nextCursorId = rawPosts.last().id.toString()
         }
 
+        val scrapPostIds = scrapRepository.findPostIdsByMemberId(member.id!!)
+
         val posts = rawPosts.map { post ->
             PostListBodyResponse(
-                    id = post.id!!,
-                    createdAt = post.createdAt!!,
-                    title = post.title,
-                    price = post.price,
-                    thumbnail = post.thumbnail,
-                    isLike = member.scrap.any { it.post == post },
-                    likeCount = post.scrapCount,
-                    isSell = post.isSell
+                id = post.id!!,
+                createdAt = post.createdAt!!,
+                title = post.title,
+                price = post.price,
+                thumbnail = post.thumbnail,
+                isLike = post.id in scrapPostIds,
+                likeCount = post.likeCount,
+                isSell = post.isSell
             )
         }
 
@@ -295,7 +297,8 @@ class PostServiceImpl(
             throw UniversityNotMatchException()
         }
 
-        if (member.scrap.any { it.post == post })
+        val scrap = scrapRepository.findScrapByMemberIdAndPostId(member.id!!, postId)
+        if (scrap != null)
             throw ScrapAlreadyExistException()
 
         scrapRepository.save(Scrap(member = member, post = post))


### PR DESCRIPTION
…s in PostQueryRepositoryImpl

<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #152 

## ✅ 작업 내용

- [x] PostQueryRepositoryImpl의 containsTitle, containsBody에서 반환될 값이 서로 바뀐 것을 수정
- [x] PostRepository의 findPostById 함수의 파라미터를 id에서 postId로 변경
- [x] NotExistMemberException 삭제
- [x] 게시글 조회 쿼리문 N+1 문제 해결

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

# 수정사항
 - PostQueryRepositoryImpl에서 containsTitle, containsBody에서 반환될 값이 서로 바뀐 것을 알았습니다.
![image](https://github.com/user-attachments/assets/b12ce55c-9454-45f6-b021-ede6a17b13d8)
분명히 inCategory쪽을 수정하면서 containsTitle과 containsBody또한 수정했을거라 생각했지만 잊고 넘어갔나 봅니다.

- PostRepository의 findPostById 함수의 파라미터를 id에서 postId로 변경했습니다.
![image](https://github.com/user-attachments/assets/a5dc3f83-ad50-4d9b-88bc-f4821ac6a341)
chat 서비스에서 postRepository를 주입하고 파라미터를 명시하는데 혼자서 id = postId만 쓰는 것 보고 변경했습니다.

- NotExistMemberException을 삭제했습니다.

#147 번 pr을 통해 회원 검증 로직을 서비스 레이어에서 제거했습니다.

- findPosts 부분의 쿼리에서 N+1 문제가 발생하던 부분을 개선했습니다.

![image](https://github.com/user-attachments/assets/cd72cfa4-66f4-474a-89a0-69873688d9ce)

기존의 코드에서는 다음과 같이 구성되었고 해당 api를 요청하면 아래와 같은 쿼리가 발생합니다.

![image](https://github.com/user-attachments/assets/4d350737-7138-47ea-9181-4fe2ef0e9b02)

해당 로그를 살펴보자면 N+1로 될 부분이 상당히 많습니다.
로그로 설명하기에는 복잡하니 제가 현재 문제가 되는 부분을 말씀드리겠습니다.

- Post 내부의 category속성(Category)을 조회하는 N+1
- Post 내부의 author속성(Member)을 조회하는 N+1
- Post 내부의 buyer속성(Member)을 조회하는 N+1
- Category 내부의 parent 속성(Category)을 조회하는 N+1

### 왜 이런 문제가 발생할까요?

위 쿼리를 예로 들자면, QueryDSL이 Post엔티티를 선택한 후 where절로 각 조건에 맞게 필터링을 설정하고 fetch를 통해 실제로 Post를 조회하게 됩니다.
이 때 Post에 속해있는 여러 연관 관계들이 Lazy Loading되었고, Post의 모든 정보를 Select 하기위해 그 안에 있는 모든것들을 반복해서 조회하게 되는 것입니다. 그래서 수많은 N+1 문제가 중첩되었습니다.

이것을 해결하기 위해서는 Post를 조회할 때 연관된 엔티티들을 한 번의 쿼리로 가져오는 방법을 사용해야 합니다. 예를 들어 fetchJoin()을 사용하면 됩니다.

### 🔧 해결 방법 1: fetchJoin

![image](https://github.com/user-attachments/assets/13231ee6-941f-43f9-aead-bcfc02700113)

fetchJoin을 사용하게 된다면 fetchJoin이 걸린 연관 엔티티도 함께 select하여 영속화를 할 수 있습니다. 즉 N+1을 피할수 있습니다.

참고로 join과 leftJoin을 혼용한 이유는 join은 non-null인 속성에 대해서 사용되었고, leftJoin은 nullable한 속성에 대해서 사용됩니다.

![image](https://github.com/user-attachments/assets/098b2f12-410e-46fd-9357-a369eecfc63c)

그렇지만 문제가 있습니다. N+1은 해결했지만 쿼리가 너무 복잡해집니다. 가독성이 떨어지고, 불필요한 모든 필드가 select 되면서 하나의 쿼리를 수행하는데 엄청난 부담이 됩니다.

그래서 저는 DTO 프로젝션을 사용해보았습니다.

### 🚀 해결 방법 2: DTO Projection

먼저 프로젝션은 SQL에서 select 절에 필요한 컬럼만 명시하는 것처럼, QueryDSL에서도 원하는 필드만 Projection 할 수 있습니다.

projection이 하나인 경우 그 값에 해당하는 타입만으로 간단하게 작성할 수 있습니다.

![image](https://github.com/user-attachments/assets/2c01ea60-a973-4045-a3bc-99e09c2c4261)

projection이 둘 이상인 경우, 튜플이나 DTO를 사용해서 조회해야 합니다.

![image](https://github.com/user-attachments/assets/01f5cb00-e6a2-445c-867b-2637a13cac4d)

위와 같이 튜플을 사용할 수 있지만, QueryDSL에서 제공하는 튜플은 서비스/컨트롤러 계층에서 사용하면 계층 간 의존성이 생겨 아키텍처가 무너질 수 있습니다. 그러므로 튜플은 레포지토리 내에서만 사용하고, DTO로 변환 후 반환하는 것이 좋습니다.

이 때 DTO로 반환하는 방법은 4가지가 있습니다.


1. bean (Setter) 매핑 (코틀린은 불가능)

2. 필드 매핑

왜인지 모르겠지만 이 방법도 오류가 났습니다.

3. @QueryProjection 사용

![image](https://github.com/user-attachments/assets/ab9ff124-88bb-456e-8850-10831bcbbd2f)

DTO에 @QueryProjection 어노테이션을 붙이고 QClass를 생성합니다.
![image](https://github.com/user-attachments/assets/e39d519a-9867-4e4b-9d8d-1b0609abfeb6)

단점이라면 까다로운 QClass를 생성해야 합니다. 작동은 됩니다.

4. 생성자 매핑
![image](https://github.com/user-attachments/assets/2eef09c6-ba21-4c54-898e-5b2d143d85ba)

@QueryProjection 어노테이션을 안붙여도 되고, 쿼리문에서 직접 생성자를 매핑하는게 제일 깔끔해 보입니다.

그래서 저는 생성자 매핑으로 DTO 프로젝션을 리팩토링 했습니다.
이로서 저는 필요한 필드만 조회하고, 불필요한 연관 객체 조회 방지라는 성과를 얻었습니다.

### 다시 한번 더 N+1 문제 발생

이 쿼리는 최선을 다했습니다. 그러나 도메인 상에서 게시글에 좋아요 여부를 표시하기 위해서는, 멤버가 해당 게시글에 좋아요를 눌렀는지 확인해야 합니다.

![image](https://github.com/user-attachments/assets/8db5a16a-389c-4bf2-b68b-d9c03ffa5d9f)

isLike 여부를 확인하기 위해서는 기존에는 post 객체끼리 비교했지만, 이제는 post id끼리 비교해야 합니다. 여기서 다시한번 N+1이 발생하게 됩니다.

이번에는 N+1을 없애기 위해 직접 JPA @Query를 작성해서 한 번에 필요한 데이터를 조회하고자 합니다.

![image](https://github.com/user-attachments/assets/5a103515-b24b-4fcb-92c1-9d7b452adf7e)

이렇게 작성한 후 판매글을 검색해보면 아래와 같이 깔끔하게 로그가 찍힙니다.
![image](https://github.com/user-attachments/assets/b6a4136d-247a-4aeb-8d79-f2dbc3520042)


![image](https://github.com/user-attachments/assets/1a85c57b-d090-44f4-84bd-5a575bd732ed)



## ✍ 궁금한 것

fetchJoin 이후에 BatchSize를 줄여도 좋아 보입니다. 게다가 커서 기반 페이지네이션이기 때문에 한 번의 요청에 최대 게시글을 21번만 조회하기 때문에 쿼리가 길어져도 충분히 버틸 수 있다고 생각합니다. 여러분은 어떻게 생각하나요? fetchJoin을 하는게 좋을까요? 아니면 프로젝션을 사용하는게 좋을까요?
