### PR TITLE
[FEAT] : 구글, 애플 소셜로그인 구현

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -92,7 +92,7 @@ jobs:
           springdoc.default-produces-media-type=application/json
           springdoc.default-consumes-media-type=application/json
           spring.security.oauth2.client.registration.google.client-id=${{ secrets.GOOGLE_CLIENT_ID }}
-          spring.security.oauth2.client.registration.google.client-secret=${{ secrets.CLIENT_SECRET }}
+          spring.security.oauth2.client.registration.google.client-secret=${{ secrets.GOOGLE_CLIENT_SECRET }}
           spring.security.oauth2.client.registration.google.scope=${{ secrets.GOOGLE_SCOPE }}
           spring.security.oauth2.client.registration.google.redirect-uri=${{ secrets.GOOGLE_REDIRECT_URI }}
           spring.security.oauth2.client.registration.google.client-name=${{ secrets.GOOGLE_CLIENT_NAME }}

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -96,6 +96,19 @@ jobs:
           spring.security.oauth2.client.registration.google.scope=${{ secrets.GOOGLE_SCOPE }}
           spring.security.oauth2.client.registration.google.redirect-uri=${{ secrets.GOOGLE_REDIRECT_URI }}
           spring.security.oauth2.client.registration.google.client-name=${{ secrets.GOOGLE_CLIENT_NAME }}
+          spring.security.oauth2.client.registration.apple.client-name=${{ secrets.APPLE_CLIENT_NAME}}
+          spring.security.oauth2.client.registration.apple.client-id=${{ secrets.APPLE_CLIENT_ID }}
+          spring.security.oauth2.client.registration.apple.client-secret=${{ secrets.APPLE_CLIENT_SECRET}}
+          spring.security.oauth2.client.registration.apple.scope=${{ secrets.APPLE_SCOPE}}
+          spring.security.oauth2.client.registration.apple.redirect-uri=${{ secrets.APPLE_REDIRECT_URI }}
+          spring.security.oauth2.client.registration.apple.authorization-grant-type=${{ secrets.APPLE_GRANT_TYPE }}
+          spring.security.oauth2.client.provider.apple.authorization-uri=${{ secrets.APPLE_AUTH_URI }}
+          spring.security.oauth2.client.provider.apple.token-uri=${{ secrets.APPLE_TOKEN_URI }}
+          spring.security.oauth2.client.provider.apple.user-info-uri=${{ secrets.APPLE_USER_INFO_URI}}
+          spring.security.oauth2.client.provider.apple.user-name-attribute=${{ secrets.APPLE_USER_NAME }}
+          apple.team_id= ${{ secrets.APPLE_TEAM_ID }}
+          apple.login_key = ${{ secrets.APPLE_LOGIN_KEY }}
+          apple.jwk-key-uri = ${{ secrets.APPLE_PUBLIC_KEY_URI }}
           EOF
 
       # docker image 빌드

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+      - TINU-159/oauth-add-apple-google
 
 jobs:
   backend-deploy:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -87,6 +87,11 @@ jobs:
           jwt.redirect.sign = ${{ secrets.JWT_REDIRECT_SIGN_URI }}
           springdoc.default-produces-media-type=application/json
           springdoc.default-consumes-media-type=application/json
+          spring.security.oauth2.client.registration.google.client-id=${{ secrets.GOOGLE_CLIENT_ID }}
+          spring.security.oauth2.client.registration.google.client-secret=${{ secrets.CLIENT_SECRET }}
+          spring.security.oauth2.client.registration.google.scope=${{ secrets.GOOGLE_SCOPE }}
+          spring.security.oauth2.client.registration.google.redirect-uri=${{ secrets.GOOGLE_REDIRECT_URI }}
+          spring.security.oauth2.client.registration.google.client-name=${{ secrets.GOOGLE_CLIENT_NAME }}
           EOF
 
       # docker image 빌드

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
       - TINU-159/oauth-add-apple-google
+  pull_request:
+    branches:
+      - TINU-159/oauth-add-apple-google
+    types: [opened, synchronize, reopened]
 
 jobs:
   backend-deploy:

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - develop
-      - TINU-159/oauth-add-apple-google
-  pull_request:
-    branches:
-      - TINU-159/oauth-add-apple-google
-    types: [opened, synchronize, reopened]
+
 
 jobs:
   backend-deploy:

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
 	//coroutine 관련 의존성 추가
 	implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1'
 	implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.1'
+
+	//Json 관련 의존성 추가
+	implementation 'org.json:json:20240303'
 }
 
 // Querydsl 설정부

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/enums/Social.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/enums/Social.kt
@@ -3,14 +3,16 @@ package com.tinuproject.tinu.domain.member.enums
 enum class Social(var code:Int, var company : String) {
     KAKAO(0, "카카오"),
     GOOGLE(1, "구글"),
-    NAVER(2, "네이버");
+    NAVER(2, "네이버"),
+    APPLE(4,"애플");
 
 
     companion object{
         fun getSocial(provider : String) : Social {
             if(provider == "Kakao") return KAKAO
             else if(provider == "Google") return GOOGLE
-            else  return NAVER
+            else if(provider == "Apple") return APPLE
+            else if(provider == "Naver") return NAVER
         }
     }
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/enums/Social.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/enums/Social.kt
@@ -9,10 +9,14 @@ enum class Social(var code:Int, var company : String) {
 
     companion object{
         fun getSocial(provider : String) : Social {
-            if(provider == "Kakao") return KAKAO
-            else if(provider == "Google") return GOOGLE
-            else if(provider == "Apple") return APPLE
-            else if(provider == "Naver") return NAVER
+            val social : Social
+
+            if(provider == "Kakao") social = KAKAO
+            else if(provider == "Google") social = GOOGLE
+            else if(provider == "Apple") social = APPLE
+            else social = NAVER
+
+            return social
         }
     }
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/enums/Social.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/enums/Social.kt
@@ -9,6 +9,7 @@ enum class Social(var code:Int, var company : String) {
     companion object{
         fun getSocial(provider : String) : Social {
             if(provider == "Kakao") return KAKAO
+            else if(provider == "Google") return GOOGLE
             else  return NAVER
         }
     }

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
@@ -1,0 +1,38 @@
+package com.tinuproject.tinu.infra.security.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+
+@Component
+data class AppleProperties(
+    @Value("\${spring.security.oauth2.client.registration.apple.client-id}")
+    val clientId : String,
+
+    @Value("\${spring.security.oauth2.client.registration.apple.client-secret}")
+    val clientSecret : String,
+
+    @Value("\${spring.security.oauth2.client.registration.apple.redirect-uri}")
+    val redirectUrl : String,
+
+    @Value("\${spring.security.oauth2.client.registration.apple.scope}")
+    val scope : String,
+
+    @Value("\${spring.security.oauth2.client.registration.apple.authorization-grant-type}")
+    val grantType : String,
+
+    @Value("\${spring.security.oauth2.client.provider.apple.token-uri}")
+    val tokenUrl : String,
+
+    @Value("\${spring.security.oauth2.client.provider.apple.user-info-uri}")
+    val  userInfoUrl : String,
+
+    @Value("\${spring.security.oauth2.client.provider.apple.user-name-attribute}")
+    val userNameAttribute : String,
+
+    @Value("\${apple.team_id}")
+    val teamId : String,
+
+    @Value("\${apple.login_key}")
+    val serviceKey : String
+)

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
@@ -34,15 +34,19 @@ data class AppleProperties(
     @Value("\${spring.security.oauth2.client.provider.apple.token-uri}")
     val tokenUrl : String,
 
+    //token(Json 형태)에서 user 정보가 담겨있는 key
     @Value("\${spring.security.oauth2.client.provider.apple.user-name-attribute}")
     val userNameAttribute : String,
 
+    //AD에서 teamId
     @Value("\${apple.team_id}")
     val teamId : String,
 
+    //AD에서 Service에 대한 Key
     @Value("\${apple.login_key}")
     val serviceKey : String,
 
+    //Apple은 공개 키 방식으로 토큰을 생성
     @Value("\${apple.jwk-key-uri}")
     val jwkUrl : String
 )

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
@@ -35,5 +35,8 @@ data class AppleProperties(
     val teamId : String,
 
     @Value("\${apple.login_key}")
-    val serviceKey : String
+    val serviceKey : String,
+
+    @Value("\${apple.jwk-key-uri}")
+    val jwkUrl : String
 )

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
@@ -4,29 +4,35 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
 
-
+//Apple social login 관련 properties를 연결하는 클래스
 @Configuration
 data class AppleProperties(
+
+    //AppleDeveloper(이후 AD)의 service Id
     @Value("\${spring.security.oauth2.client.registration.apple.client-id}")
     val clientId : String,
 
+    //AD에서 발급받은 secret 파일 속 Key
     @Value("\${spring.security.oauth2.client.registration.apple.client-secret}")
     val clientSecret : String,
 
+    //소셜로그인 성공이후 인증 Code를 받아올 RedirectUrl
     @Value("\${spring.security.oauth2.client.registration.apple.redirect-uri}")
     val redirectUrl : String,
 
+    //소셜로그인을 통해 받아올 추가 정보(기본은 AccessToken, RefreshToken, IdToken)
     @Value("\${spring.security.oauth2.client.registration.apple.scope}")
     val scope : String,
 
+    //소셜로그인을 통해 유저 정보를 어떻게 받아올지
+    //해당 방식은 로그인 -> 인증 코드 -> 토큰의 과정을 거치는 방식
     @Value("\${spring.security.oauth2.client.registration.apple.authorization-grant-type}")
     val grantType : String,
 
+
+    //Code를 통해 Token을 받아오는 URI
     @Value("\${spring.security.oauth2.client.provider.apple.token-uri}")
     val tokenUrl : String,
-
-    @Value("\${spring.security.oauth2.client.provider.apple.user-info-uri}")
-    val  userInfoUrl : String,
 
     @Value("\${spring.security.oauth2.client.provider.apple.user-name-attribute}")
     val userNameAttribute : String,

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/AppleProperties.kt
@@ -1,10 +1,11 @@
 package com.tinuproject.tinu.infra.security.config
 
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
 
 
-@Component
+@Configuration
 data class AppleProperties(
     @Value("\${spring.security.oauth2.client.registration.apple.client-id}")
     val clientId : String,

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/SecurityConfig.kt
@@ -5,10 +5,14 @@ import com.tinuproject.tinu.domain.member.repository.MemberRepository
 import com.tinuproject.tinu.infra.security.filter.ExceptionHandlerFilter
 import com.tinuproject.tinu.infra.security.filter.JwtTokenFilter
 import com.tinuproject.tinu.infra.security.filter.SignUpFilter
+import com.tinuproject.tinu.infra.security.jwt.AppleJwtGenerator
 import com.tinuproject.tinu.infra.security.jwt.JwtUtil
 import com.tinuproject.tinu.infra.security.oauth.handler.OAuthLoginFailureHandler
 import com.tinuproject.tinu.infra.security.oauth.handler.OAuthLoginSuccessHandler
+import com.tinuproject.tinu.infra.security.oauth.resolver.CustomAuthorizationRequestResolver
 import com.tinuproject.tinu.infra.security.oauth.service.CustomOAuth2UserService
+import com.tinuproject.tinu.infra.security.oauth.tokenresponseclient.AppleTokenResponseClient
+import com.tinuproject.tinu.infra.security.oauth.tokenresponseclient.CustomTokenResponseClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -26,6 +30,7 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
@@ -39,7 +44,8 @@ class SecurityConfig(
     private val memberRepository: MemberRepository,
     @Value("\${web.allowed-path}")
     private val allowedPaths : List<String>,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val customTokenResponseClient: CustomTokenResponseClient
 ) {
 
     @Bean
@@ -66,7 +72,9 @@ class SecurityConfig(
 
     @Bean
     @Throws(Exception::class)
-    fun filterChain(httpSecurity: HttpSecurity, memberRepository: MemberRepository): SecurityFilterChain {
+    fun filterChain(httpSecurity: HttpSecurity, memberRepository: MemberRepository, clientRegistrationRepository: ClientRegistrationRepository,
+                    appleJwtGenerator: AppleJwtGenerator
+    ): SecurityFilterChain {
         val sessionManagement = httpSecurity.httpBasic { obj: HttpBasicConfigurer<HttpSecurity> -> obj.disable() }
             //cors 설정
             .cors { corsConfigurer: CorsConfigurer<HttpSecurity?> ->
@@ -86,8 +94,15 @@ class SecurityConfig(
             )
             .oauth2Login { oauth: OAuth2LoginConfigurer<HttpSecurity?> ->  // OAuth2 로그인 기능에 대한 여러 설정의 진입점
                 oauth
+                    .authorizationEndpoint{ endpoint ->
+                        endpoint
+                            .authorizationRequestResolver(CustomAuthorizationRequestResolver(clientRegisterRepository = clientRegistrationRepository))
+                    }
                     .userInfoEndpoint { userInfo ->
                         userInfo.userService(customOAuth2UserService) // CustomOAuth2UserService 등록
+                    }
+                    .tokenEndpoint{ token ->
+                        token.accessTokenResponseClient(customTokenResponseClient)
                     }
                     //TODO(로그인이 필요한데 안된 부분이 있으면 넘길 수 있는 것.)- 기본은 (백엔드 도메인)/login
                     //.loginPage("http://localhost:8080/loginpage.html").permitAll()

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/SecurityConfig.kt
@@ -30,6 +30,7 @@ import org.springframework.security.config.annotation.web.configurers.HttpBasicC
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer
 import org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
@@ -45,7 +46,6 @@ class SecurityConfig(
     @Value("\${web.allowed-path}")
     private val allowedPaths : List<String>,
     private val objectMapper: ObjectMapper,
-    private val customTokenResponseClient: CustomTokenResponseClient
 ) {
 
     @Bean
@@ -102,7 +102,7 @@ class SecurityConfig(
                         userInfo.userService(customOAuth2UserService) // CustomOAuth2UserService 등록
                     }
                     .tokenEndpoint{ token ->
-                        token.accessTokenResponseClient(customTokenResponseClient)
+                        token.accessTokenResponseClient(CustomTokenResponseClient(appleTokenResponseClient = AppleTokenResponseClient{appleJwtGenerator.generate()}, defaultClient = DefaultAuthorizationCodeTokenResponseClient()))
                     }
                     //TODO(로그인이 필요한데 안된 부분이 있으면 넘길 수 있는 것.)- 기본은 (백엔드 도메인)/login
                     //.loginPage("http://localhost:8080/loginpage.html").permitAll()

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/AppleJwtGenerator.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/AppleJwtGenerator.kt
@@ -3,6 +3,7 @@ package com.tinuproject.tinu.infra.security.jwt
 import com.tinuproject.tinu.infra.security.config.AppleProperties
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.context.annotation.Bean
 import org.springframework.stereotype.Component
 import java.security.KeyFactory
 import java.security.PrivateKey
@@ -16,6 +17,7 @@ import java.util.Date.*
 class AppleJwtGenerator(
     val appleProperties: AppleProperties
 ) {
+    @Bean
     fun generate(): String{
         val now = Instant.now()
 

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/AppleJwtGenerator.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/AppleJwtGenerator.kt
@@ -1,0 +1,46 @@
+package com.tinuproject.tinu.infra.security.jwt
+
+import com.tinuproject.tinu.infra.security.config.AppleProperties
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.stereotype.Component
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.*
+import java.util.Date.*
+
+@Component
+class AppleJwtGenerator(
+    val appleProperties: AppleProperties
+) {
+    fun generate(): String{
+        val now = Instant.now()
+
+        val exp = now.plus(180,ChronoUnit.DAYS)
+
+        return Jwts.builder()
+            .setHeaderParam("kid", appleProperties.serviceKey)
+            .setIssuer(appleProperties.teamId)
+            .setIssuedAt(from(now))
+            .setExpiration(from(exp))
+            .setAudience("https://appleid.apple.com")
+            .setSubject(appleProperties.clientId)
+            .signWith(loadPrivateKey(), SignatureAlgorithm.ES256)
+            .compact()
+    }
+
+    private fun loadPrivateKey() : PrivateKey {
+        val privateKeyPem = appleProperties.clientSecret
+            .replace("-----BEGIN PRIVATE KEY-----","")
+            .replace("-----END PRIVATE KEY-----","")
+            .replace("\\s+".toRegex(),"")
+
+        val keyBytes = Base64.getDecoder().decode(privateKeyPem)
+        val keySpec = PKCS8EncodedKeySpec(keyBytes)
+
+        return KeyFactory.getInstance("EC").generatePrivate(keySpec)
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/AppleJwtGenerator.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/jwt/AppleJwtGenerator.kt
@@ -14,10 +14,12 @@ import java.util.*
 import java.util.Date.*
 
 @Component
+//Apple에서는 code를 통해 Token을 요청할 때 client_secret으로 Jwt토큰 방식을 요구함.
+//그렇기에 해당 client_secret에 넣을 토큰을 생성하는 클래스
 class AppleJwtGenerator(
     val appleProperties: AppleProperties
 ) {
-    @Bean
+
     fun generate(): String{
         val now = Instant.now()
 
@@ -34,6 +36,10 @@ class AppleJwtGenerator(
             .compact()
     }
 
+    //private key를 받는 방법 2가지
+    //제공 받은 privateKey 파일에서 추출
+    //privateKey에서 Key 부분만 추출해서 secret에 넣음
+    //현재는 secret에서 추출
     private fun loadPrivateKey() : PrivateKey {
         val privateKeyPem = appleProperties.clientSecret
             .replace("-----BEGIN PRIVATE KEY-----","")

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/dto/AppleUserInfo.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/dto/AppleUserInfo.kt
@@ -1,0 +1,17 @@
+package com.tinuproject.tinu.infra.security.oauth.dto
+
+class AppleUserInfo(
+    private var attributes: Map<String, Any>
+): OAuth2UserInfoDto  {
+    override fun getProviderId(): String {
+        return attributes["sub"] as String
+    }
+
+    override fun getProvider(): String {
+        return "apple"
+    }
+
+    override fun getName(): String {
+        return attributes["name"] as String
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/dto/AppleUserInfo.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/dto/AppleUserInfo.kt
@@ -12,6 +12,6 @@ class AppleUserInfo(
     }
 
     override fun getName(): String {
-        return attributes["name"] as String
+        return "DELETABLE"
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/dto/GoogleUserInfo.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/dto/GoogleUserInfo.kt
@@ -1,0 +1,18 @@
+package com.tinuproject.tinu.infra.security.oauth.dto
+
+class GoogleUserInfo(
+    private var attributes: Map<String, Any>
+) : OAuth2UserInfoDto{
+
+    override fun getProviderId(): String {
+        return attributes["sub"] as String
+    }
+
+    override fun getProvider(): String {
+        return "google"
+    }
+
+    override fun getName(): String {
+        return attributes["name"] as String
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/resolver/CustomAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/resolver/CustomAuthorizationRequestResolver.kt
@@ -1,0 +1,49 @@
+package com.tinuproject.tinu.infra.security.oauth.resolver
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+
+class CustomAuthorizationRequestResolver(
+    clientRegisterRepository: ClientRegistrationRepository
+) : OAuth2AuthorizationRequestResolver{
+    val defaultResolver = DefaultOAuth2AuthorizationRequestResolver(
+        clientRegisterRepository,
+        OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI
+    )
+
+    override fun resolve(request: HttpServletRequest): OAuth2AuthorizationRequest {
+        val resolved = defaultResolver.resolve(request)?: throw Exception("소셜 로그인 실패")
+
+        val registrationId = request.getParameter("registrationId") ?: extractRegistrationId(request)
+
+        return if (registrationId=="apple"){
+            OAuth2AuthorizationRequest.from(resolved)
+                .additionalParameters { it["response_mod"] = "form_post" }
+                .build()
+        }else{
+            resolved
+        }
+    }
+
+    override fun resolve(request: HttpServletRequest?, clientRegistrationId: String?): OAuth2AuthorizationRequest {
+        val resolved = defaultResolver.resolve(request, clientRegistrationId) ?: throw Exception("소셜 로그인 실패")
+
+        return if (clientRegistrationId=="apple"){
+            OAuth2AuthorizationRequest.from(resolved)
+                .additionalParameters { it["response_mod"] = "form_post" }
+                .build()
+        }else{
+            resolved
+        }
+    }
+
+
+    private fun extractRegistrationId(request: HttpServletRequest) : String{
+        val uri = request.requestURI
+        return uri.substringAfterLast("/")
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/resolver/CustomAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/resolver/CustomAuthorizationRequestResolver.kt
@@ -6,7 +6,9 @@ import org.springframework.security.oauth2.client.web.DefaultOAuth2Authorization
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+import org.springframework.stereotype.Component
 
+@Component
 class CustomAuthorizationRequestResolver(
     clientRegisterRepository: ClientRegistrationRepository
 ) : OAuth2AuthorizationRequestResolver{
@@ -15,26 +17,26 @@ class CustomAuthorizationRequestResolver(
         OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI
     )
 
-    override fun resolve(request: HttpServletRequest): OAuth2AuthorizationRequest {
-        val resolved = defaultResolver.resolve(request)?: throw Exception("소셜 로그인 실패")
+    override fun resolve(request: HttpServletRequest): OAuth2AuthorizationRequest? {
+        val resolved = defaultResolver.resolve(request)?: return null
 
         val registrationId = request.getParameter("registrationId") ?: extractRegistrationId(request)
 
         return if (registrationId=="apple"){
             OAuth2AuthorizationRequest.from(resolved)
-                .additionalParameters { it["response_mod"] = "form_post" }
+                .additionalParameters { it["response_mode"] = "form_post" }
                 .build()
         }else{
             resolved
         }
     }
 
-    override fun resolve(request: HttpServletRequest?, clientRegistrationId: String?): OAuth2AuthorizationRequest {
-        val resolved = defaultResolver.resolve(request, clientRegistrationId) ?: throw Exception("소셜 로그인 실패")
+    override fun resolve(request: HttpServletRequest?, clientRegistrationId: String?): OAuth2AuthorizationRequest? {
+        val resolved = defaultResolver.resolve(request, clientRegistrationId) ?:return null
 
         return if (clientRegistrationId=="apple"){
             OAuth2AuthorizationRequest.from(resolved)
-                .additionalParameters { it["response_mod"] = "form_post" }
+                .additionalParameters { it["response_mode"] = "form_post" }
                 .build()
         }else{
             resolved

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/resolver/CustomAuthorizationRequestResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/resolver/CustomAuthorizationRequestResolver.kt
@@ -8,6 +8,8 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.stereotype.Component
 
+//apple에서 scope가 있는 경우 요청의 response_mode가 form_post여야함.
+//하지만 security의 기본값은 query이기때문에 apple 일 때의 분기처리가 필요하여 이를 처리하는 클래스
 @Component
 class CustomAuthorizationRequestResolver(
     clientRegisterRepository: ClientRegistrationRepository

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
@@ -28,7 +28,7 @@ class AppleOAuth2UserService(
         val claims = parseIdToken(idToken)
 
         val attributes = mapOf(
-          appleProperties.userNameAttribute to claims["sub"]
+          appleProperties.userNameAttribute to claims[appleProperties.userNameAttribute]
         )
 
         return DefaultOAuth2User(

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
@@ -22,11 +22,14 @@ class AppleOAuth2UserService(
 ) {
 
     fun appleLoadUser(userRequest : OAuth2UserRequest?) : OAuth2User{
+        //Apple은 소셜 로그인시 유저 정보를 idToken에 담아서 전달해줌.
         val idToken = userRequest!!.additionalParameters["id_token"] as? String
             ?: throw Exception("소셜 로그인 실패")
 
+        //해당 idToken의 Claims들을 파싱
         val claims = parseIdToken(idToken)
 
+        //idToken에 "sub" 키에 유저들의 정보가 담김 이를 자바 Map으로 연결
         val attributes = mapOf(
           appleProperties.userNameAttribute to claims[appleProperties.userNameAttribute]
         )
@@ -47,6 +50,8 @@ class AppleOAuth2UserService(
         return jwt.body
     }
 
+    //Apple의 id_Token의 검증은 Apple Database에서 관리하는 공개키를 통해 가능함.
+    //이를 JsonObject로 받아오고 맞는 공개키를 찾는 과정.
     private fun getApplePublicKey(idToken:String) : PublicKey{
         val parts = idToken.split(".")
 
@@ -58,6 +63,8 @@ class AppleOAuth2UserService(
 
         val jwksUrl = URL(appleProperties.jwkUrl)
 
+        //현재는 모든 요청에 대해 Apple에게 PK를 받지만
+        //성능 향상으로 한번 불러온 PK에 대해 캐싱하면 성능 향상이 가능할 것 같음.
         val jwks = JSONObject(jwksUrl.readText())
 
         val keys = jwks.getJSONArray("keys")

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
@@ -42,7 +42,7 @@ class AppleOAuth2UserService(
 
         val parser = Jwts.parserBuilder().setSigningKey(getApplePublicKey(idToken)).build()
 
-        val jwt = parser.parseClaimsJwt(idToken)
+        val jwt = parser.parseClaimsJws(idToken)
 
         return jwt.body
     }

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
@@ -1,0 +1,33 @@
+package com.tinuproject.tinu.infra.security.oauth.service
+
+import com.tinuproject.tinu.infra.security.config.AppleProperties
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Component
+
+@Component
+class AppleOAuth2UserService(
+    val appleProperties: AppleProperties
+) {
+
+    fun appleLoadUser(userRequest : OAuth2UserRequest?) : OAuth2User{
+        val idToken = userRequest!!.additionalParameters["id_token"] as? String
+            ?: throw Exception("소셜 로그인 실패")
+
+        val claims = parseIdToken(idToken)
+
+        val attributes = mapOf(
+          appleProperties.userNameAttribute to claims["sub"]
+        )
+
+        return DefaultOAuth2User(
+            listOf(SimpleGrantedAuthority("ROLE_USER")),
+            attributes,
+            appleProperties.userNameAttribute
+        )
+    }
+
+
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
@@ -1,6 +1,7 @@
 package com.tinuproject.tinu.infra.security.oauth.service
 
 import com.tinuproject.tinu.infra.security.config.AppleProperties
+import io.jsonwebtoken.Jwts
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
@@ -37,6 +38,14 @@ class AppleOAuth2UserService(
         )
     }
 
+    private fun parseIdToken(idToken:String) : Map<String, Any>{
+
+        val parser = Jwts.parserBuilder().setSigningKey(getApplePublicKey(idToken)).build()
+
+        val jwt = parser.parseClaimsJwt(idToken)
+
+        return jwt.body
+    }
 
     private fun getApplePublicKey(idToken:String) : PublicKey{
         val parts = idToken.split(".")

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/AppleOAuth2UserService.kt
@@ -6,6 +6,14 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Component
+import java.security.PublicKey
+import java.util.*
+import org.json.JSONObject
+import java.math.BigInteger
+import java.net.URL
+import java.security.KeyFactory
+import java.security.spec.RSAPublicKeySpec
+import kotlin.math.exp
 
 @Component
 class AppleOAuth2UserService(
@@ -29,5 +37,39 @@ class AppleOAuth2UserService(
         )
     }
 
+
+    private fun getApplePublicKey(idToken:String) : PublicKey{
+        val parts = idToken.split(".")
+
+        val headerJson = String(Base64.getUrlDecoder().decode(parts[0]))
+
+        val header = JSONObject(headerJson)
+
+        val kid = header.getString("kid")
+
+        val jwksUrl = URL(appleProperties.jwkUrl)
+
+        val jwks = JSONObject(jwksUrl.readText())
+
+        val keys = jwks.getJSONArray("keys")
+
+        for(i in 0 until keys.length()){
+            val key = keys.getJSONObject(i)
+            if(key.getString("kid")==kid){
+                val n = key.getString("n")
+                val e = key.getString("e")
+
+                val modulus = BigInteger(1,Base64.getUrlDecoder().decode(n))
+
+                val exponent = BigInteger(1, Base64.getUrlDecoder().decode(e))
+
+                val keySpec = RSAPublicKeySpec(modulus, exponent)
+
+                return KeyFactory.getInstance("RSA").generatePublic(keySpec)
+            }
+        }
+
+        throw Exception("소셜 로그인 실패.")
+    }
 
 }

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
@@ -27,6 +27,8 @@ class CustomOAuth2UserService(
     override fun loadUser(userRequest: OAuth2UserRequest?): OAuth2User {
 
         val provider :String = userRequest!!.clientRegistration.clientName
+        //Apple은 사용자 정보를 id_token 안에 JWT 형태로만 제공해서 Security에서 기본으로 loadUser
+        // 기능으로 처리가 불가능하여 별도로 구현 및 분기처리를 해줘야함
         val oauth2User : OAuth2User = if(provider == "Apple"){
             appleOAuth2UserService.appleLoadUser(userRequest)
         }else{

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
@@ -16,7 +16,8 @@ import java.util.*
 @Service
 class CustomOAuth2UserService(
     private val userRepository: SocialMemberRepository,
-    private val refreshTokenRepository : RefreshTokenRepository
+    private val refreshTokenRepository : RefreshTokenRepository,
+    private val appleOAuth2UserService: AppleOAuth2UserService
 ): DefaultOAuth2UserService() {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
@@ -26,8 +27,11 @@ class CustomOAuth2UserService(
     override fun loadUser(userRequest: OAuth2UserRequest?): OAuth2User {
 
         val provider :String = userRequest!!.clientRegistration.clientName
-
-        val oauth2User : OAuth2User = super.loadUser(userRequest)
+        val oauth2User : OAuth2User = if(provider == "Apple"){
+            appleOAuth2UserService.appleLoadUser(userRequest)
+        }else{
+            super.loadUser(userRequest)
+        }
 
 
         when (provider) {

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
@@ -42,6 +42,11 @@ class CustomOAuth2UserService(
                 oAuth2UserInfo =
                     NaverUserInfo(oauth2User.attributes["response"] as Map<String, Any>)
             }
+
+            "Google" -> {
+                log.info("구글 로그인 요청")
+                oAuth2UserInfo = GoogleUserInfo(oauth2User.attributes)
+            }
         }
 
         val providerId = oAuth2UserInfo!!.getProviderId()

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/service/CustomOAuth2UserService.kt
@@ -51,6 +51,11 @@ class CustomOAuth2UserService(
                 log.info("구글 로그인 요청")
                 oAuth2UserInfo = GoogleUserInfo(oauth2User.attributes)
             }
+
+            "Apple" -> {
+                log.info("애플 로그인 요청")
+                oAuth2UserInfo = AppleUserInfo(oauth2User.attributes)
+            }
         }
 
         val providerId = oAuth2UserInfo!!.getProviderId()

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
@@ -1,0 +1,70 @@
+package com.tinuproject.tinu.infra.security.oauth.tokenresponseclient
+
+import com.tinuproject.tinu.global.response.ResponseEntityGenerator
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest
+import org.springframework.security.oauth2.core.OAuth2AccessToken
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.client.exchange
+
+
+class AppleTokenResponseClient(
+    private val jwtGenerator: () -> String
+) : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>{
+
+    private val restTemplate = RestTemplate()
+
+    val log : Logger = LoggerFactory.getLogger(this::class.java)
+    override fun getTokenResponse(request: OAuth2AuthorizationCodeGrantRequest): OAuth2AccessTokenResponse {
+        val clientRegistration = request.clientRegistration
+        val redirectUri = request.authorizationExchange.authorizationRequest.redirectUri
+        val code = request.authorizationExchange.authorizationResponse.code
+
+        val jwtToken = jwtGenerator()
+
+        val formData = LinkedMultiValueMap<String, String>().apply {
+            add("client_id", clientRegistration.clientId)
+            add("client_secret",jwtToken)
+            add("code",code)
+            add("grant_type", "authorization_code")
+            add("redirect_uri", redirectUri)
+        }
+
+
+        val headers = HttpHeaders().apply {
+            contentType =  MediaType.APPLICATION_FORM_URLENCODED
+        }
+
+        val entity = HttpEntity(formData, headers)
+
+
+        val response = restTemplate.exchange(
+            clientRegistration.providerDetails.tokenUri,
+            HttpMethod.POST,
+            entity,
+            object : ParameterizedTypeReference<Map<String, Any>>(){}
+        ).body ?: throw Exception("소셜 로그인 실패 Exception")
+
+        val accessToken = response["access_token"] as String
+        val refreshToken = response["refresh_token"] as? String
+        val expiresIn = (response["expires_in"]as Number).toLong()
+
+
+        return OAuth2AccessTokenResponse.withToken(accessToken)
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .expiresIn(expiresIn)
+            .refreshToken(refreshToken)
+            .scopes(clientRegistration.scopes)
+            .additionalParameters(response)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
@@ -19,9 +19,9 @@ import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.exchange
 
 
-@Component
+
 class AppleTokenResponseClient(
-    private val appleJwtGenerator: AppleJwtGenerator
+    private val generator : () -> String
 ) : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>{
 
     private val restTemplate = RestTemplate()
@@ -32,7 +32,7 @@ class AppleTokenResponseClient(
         val redirectUri = request.authorizationExchange.authorizationRequest.redirectUri
         val code = request.authorizationExchange.authorizationResponse.code
 
-        val jwtToken = appleJwtGenerator.generate()
+        val jwtToken = generator()
 
         val formData = LinkedMultiValueMap<String, String>().apply {
             add("client_id", clientRegistration.clientId)

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
@@ -21,6 +21,7 @@ import org.springframework.web.client.exchange
 
 
 class AppleTokenResponseClient(
+    //Kotlin은 자바와 달리 함수형 매개변수를 Class에서도 사용 가능.
     private val generator : () -> String
 ) : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>{
 
@@ -67,6 +68,7 @@ class AppleTokenResponseClient(
             .expiresIn(expiresIn)
             .refreshToken(refreshToken)
             .scopes(clientRegistration.scopes)
+            //해당 response에 id_Token이 저장되어 있음.
             .additionalParameters(response)
             .build()
     }

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/AppleTokenResponseClient.kt
@@ -1,6 +1,7 @@
 package com.tinuproject.tinu.infra.security.oauth.tokenresponseclient
 
 import com.tinuproject.tinu.global.response.ResponseEntityGenerator
+import com.tinuproject.tinu.infra.security.jwt.AppleJwtGenerator
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.core.ParameterizedTypeReference
@@ -12,13 +13,15 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResp
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest
 import org.springframework.security.oauth2.core.OAuth2AccessToken
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.client.exchange
 
 
+@Component
 class AppleTokenResponseClient(
-    private val jwtGenerator: () -> String
+    private val appleJwtGenerator: AppleJwtGenerator
 ) : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>{
 
     private val restTemplate = RestTemplate()
@@ -29,7 +32,7 @@ class AppleTokenResponseClient(
         val redirectUri = request.authorizationExchange.authorizationRequest.redirectUri
         val code = request.authorizationExchange.authorizationResponse.code
 
-        val jwtToken = jwtGenerator()
+        val jwtToken = appleJwtGenerator.generate()
 
         val formData = LinkedMultiValueMap<String, String>().apply {
             add("client_id", clientRegistration.clientId)

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/CustomTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/CustomTokenResponseClient.kt
@@ -3,7 +3,9 @@ package com.tinuproject.tinu.infra.security.oauth.tokenresponseclient
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+import org.springframework.stereotype.Component
 
+@Component
 class CustomTokenResponseClient(
     private val appleTokenResponseClient: OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>,
     private val defaultClient : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/CustomTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/CustomTokenResponseClient.kt
@@ -1,0 +1,23 @@
+package com.tinuproject.tinu.infra.security.oauth.tokenresponseclient
+
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
+
+class CustomTokenResponseClient(
+    private val appleTokenResponseClient: OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>,
+    private val defaultClient : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>
+) : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>{
+    override fun getTokenResponse(authorizationGrantRequest: OAuth2AuthorizationCodeGrantRequest): OAuth2AccessTokenResponse {
+        val registrationId = authorizationGrantRequest.clientRegistration.registrationId
+
+
+        return if ( registrationId == "apple"){
+            appleTokenResponseClient.getTokenResponse(authorizationGrantRequest)
+        }else{
+            defaultClient.getTokenResponse(authorizationGrantRequest)
+        }
+    }
+
+
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/CustomTokenResponseClient.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/tokenresponseclient/CustomTokenResponseClient.kt
@@ -5,7 +5,7 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCo
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse
 import org.springframework.stereotype.Component
 
-@Component
+
 class CustomTokenResponseClient(
     private val appleTokenResponseClient: OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>,
     private val defaultClient : OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #156 

## ✅ 작업 내용

- [ ] 구글 소셜로그인 구현
- [ ] 애플 소셜로그인 구현

## 0️⃣ 소셜 로그인에 대하여
## 📄  Google vs Naver, Kakao vs Apple

**Java Spring Security 단**에서 
1. Google
2. Naver, Kakao
3. Apple
3 항목의 OAuth2 소셜 로그인은 **차이가 존재**합니다.

### 공식 OAuth2.0 프로토콜 준수 여부( Google, Naver, Kakao vs Apple )
#### **Google, Naver, Kakao**
Google과 Naver, Kakao의 경우 공식 OAuth2.0 프로토콜을 준수합니다.

공식 OAuth2.0 프로토콜의 경우 **소셜 로그인 -> 인증 코드 -> 토큰 -> 유저정보 조회**의 순서로 정보를 받아오는 과정을 거칩니다.

Spring Security에서는 해당 **공식 OAuth 2.0 프로토콜에 따른 소셜 로그인 과정을 지원**하며
**application.properties** 혹은 **yml**에서 **OAuth login** 관련해 주어진 프로퍼티 key에 알맞은 값을 넣으면 **@AOP**에 따라 자동으로 
소셜로그인 구현을 해줍니다.


#### **Apple**
그에 반해 Apple의 경우 공식 OAuth2.0 프로토콜을 **일부만 준수**하는 차이가 있습니다

공식 OAuth2.0프로토콜과의 차이는 다음과 같습니다.

**1. OAuth 로그인 과정**
앞선 단계에서 한 단계 줄어든 **소셜 로그인 -> 인증 코드 -> 토큰**의 순서로 받아오는 과정을 거치며

마지막 단계에서 Apple에서 apple Api를 사용할 **A.T**와  유저 정보가 담긴 **IdToken**을 반환해줍니다.

개발자는 해당 idToken에서 사용자 정보(providerId 나 기타 추가 정보)를 직접 파싱하여 관리해야합니다.

**2. Code 요청시 response_mode**
**[response_mode를 query로 했을 때]**
![image](https://github.com/user-attachments/assets/85cad01c-317c-4ee0-b567-56e1f0c2e802)

Apple에서는 인가 코드를 요청할 때 response_mode를 form_post로 지정해줘야한다는 차이도 존재합니다.

물론 항상 그런 것은 아니고 scope에 **email**이나 **name**과 같은 **추가 정보를 요청할 경우에 지정**해주게 됩니다.

**추가 정보를 지정하지 않으면 query**로도 정상 작동합니다.

그 외에는 apple의 경우 OAuth 과정을 진행하는 request 측에서도 **https 통신**을 통해 진행해야한다는 차이가 있습니다.

**3. Token 요청시 Client_secret  형태**

일반 OAuth2에서는 client_secret을 단순 문자열로 전달합니다.
하지만 Apple에서는 단순 String이 아닌 JWT토큰으로 이루어져 있으며 
![image](https://github.com/user-attachments/assets/9c18b2c3-c757-49ce-b810-49d8d04bcf65)
Apple에서 발급받은 private key (.p8)를 사용해 ES256 알고리즘으로 서명해야 합니다. 

**차이점으로 인한 구현에서의 차이**

그렇기에 Apple의 경우 Naver, Google, Kakao와 달리 소셜 로그인을 하기 위해서는 **Spring Security를 별도로 커스터마이즈** 해주어야합니다.

### Spring Security provider 지원 여부 ( Google vs kakao, naver )

Spring Security에서는 **OAuth2 클라이언트 설정**을 application.**yml** 또는 application**.properties**에서 
다음 **두 가지 큰 범주로** 나눠서 구성합니다:

![image](https://github.com/user-attachments/assets/1812c318-edc2-455a-b178-0dd0a50dc51d)


1. **register**는 소셜 로그인을 사용하기 위해 앱 등록한 측에서 설정하는 내용으로 redirect Uri, client-id, client-secret 등 
개발자 측면에서 발급 받거나 설정하는 내용이 담겼고

2. **provider**는 OAuth2 서버(즉, 소셜 로그인 제공자)의 정보들을 설정하는 것으로 인증 코드를 요청하는 url,, 유저 정보를 요청하는 url, 결과에서 어떤 key로 유저 정보가 담겨있는지 하는 내용이 담겨있습니다.

이 두 설정에서 provider 측이 google 과 kakao, naver에서 차이가 납니다.

kakao와 naver에 비해 google 좀 더 세계적 기업인만큼 
Spring Security의 **CommonOAuth2Provider** enum class에서 google의 provider가 저장되고 관리되어 있습니다.
(package org.springframework.security.config.oauth2.client;)

그렇기에 **google은 register**에 관한 내용만, **kakao와 naver는 register + provider**에 대한 내용 모두를 넣어주어야
Spring securioty가 이를 인식하고 자동으로 **OAuth login 과정을 등록**해줍니다.

### 그렇기에?
이번에 개발하는 Apple 로그인과 Google 로그인에서

Google 로그인은 **앱 등록 및 properties register 추가**

Apple은 앱 등록 및 프로퍼티 **register + provider 추가 및 security 커스터 마이즈**가 필요합니다.

단 이번 구현에서 애플리케이션 등록의 경우엔 **제가 참고한 url**로 대체하겠습니다.

## 1️⃣ 구글 로그인 구현
### 애플리케이션 등록
url : https://dnjfht.tistory.com/149

### applicaition properties 작성
![image](https://github.com/user-attachments/assets/aa3836bd-11aa-4703-8fab-96ba90cc4ebc)

Google의 경우 위에서 설명 했듯이 register 내용만 채워주면 자동으로 OAuth 과정을 등록해줍니다.

register에서는 아래의 정보들을 추가해주면 됩니다.

**client-id** : OAuth Client 생성 시 발급 받은 id
**client-secret** : OAuth Client 생성 시 발급 받은 secret
**scope** : 기본 정보(providerId 외)를 제외하고 추가로 요청하는 정보들
**redirect-uri** : 소셜로그인 성공 이후 인가 코드를 보내올 uri
**client-name** : 소셜 로그인 과정에서 관리할 클라이언트 이름(해당 이름으로 /login 화면 구성 및 clientname 결정)

### google 소셜로그인 분기 처리
위의 properties 과정으로만도 소셜로그인 등록은 완료되지만 모든 과정 이후 어떻게 유저 정보를 관리해줄 지에 대한 내용이 추가 되어야합니다.

해당 내용은 CustomOAuth2UserService에서 진행 되며

![image](https://github.com/user-attachments/assets/b580809e-acfc-4dbd-bfbb-ca1542da3d0b)

이 처럼 로그인 성공 이후 provider에 따라 분기처리를 진행하였습니다.

*** 결과 화면
![image](https://github.com/user-attachments/assets/639cdcaf-1c73-47ea-b1dd-2be1e47fbfe4)

정상적으로 Google 로그인이 등록된 것을 알 수 있으며

![image](https://github.com/user-attachments/assets/f4df4b1d-9ee6-49f4-a5e5-0ff489d6a092)

![image](https://github.com/user-attachments/assets/89ca9385-44f3-493e-8f06-0385a73d548d)

로그인 이후 정상적으로 회원가입 페이지까지 리다이렉트 됨을 알 수 있습니다.

## 2️⃣ 애플 로그인 구현
### 애플리케이션 등록
url : https://shxrecord.tistory.com/289

### 관련 프로퍼티 추가
커스터마이즈를 하더라도 Security 내에서 작동하게 하기 위해서는 다른 기업과 같이 프로퍼티를 추가해주어야합니다.

Google과 달리 Register와 Provider를 추가해주어야하고, 그외 apple 로그인에서만 쓰이는 별도의 프로퍼티도 존재합니다.

![image](https://github.com/user-attachments/assets/ca3412f3-35ab-4b27-a747-5562758b4ccb)

register의 경우 google과 유사합니다.

### Apple 커스터마이즈
#### 소셜로그인 완료 분기처리
![image](https://github.com/user-attachments/assets/ee4498ee-4062-40c0-aa7b-be359370636b)
마찬가지로 소셜로그인 이후 Apple의 내용을 추가해줍니다.

#### AuthorizationRequest 커스터마이즈
해당 AuthorizationRequest는 인가 코드에대한 요청 정보를 담고 있으며 Apple 의 경우 response_mode가 form_post로 구성되어야하기 때문에 이를 처리하는 클래스가 필요합니다.

해당 작업에서는 **CustomAuthorizationRequestResolver** 에서 처리해주고 있습니다.
분기 처리 내용은 간단한 것이 기존 request에 대해 혹시 registrationId가 apple 일 경우 response_mode를 변경해주는 간단한 로직입니다. 이때 **registerationId의 경우 properties를 설정해줄 때 registration 뒤에 붙는 이름**에 해당합니다

![image](https://github.com/user-attachments/assets/56fea580-f3af-410b-b6d1-97de0d408d60)


#### 인가 코드 -> Token 과정 커스터마이즈
Apple에서 인가코드를 통해 Token을 요청할 때
ClientSecret은 JWT로 구성하여 보내줄 필요가 있습니다.

그렇기에 client_secret을 따로 만드는 커스터마이즈가 필요하며, 해당 과정은 AppletokenresponseClient와 AppleJwtGenerator에서 작성되어있습니다.

TokenReponseclient는 실질적으로 Code로 Token을 요청하는 부분, AppleJwtGenerator 는 Client_Secret을 위한 JWT 생성 로직이 담겨 있습니다.

이때 Client Secret에서는 
![image](https://github.com/user-attachments/assets/d384e58e-102f-4a47-a2c0-cccb1629fa59)

와 같이
- kid(serviceKey)
- teamId
- clientId
- 서명 등이 담김을 알 수 있습니다.   



### Token -> 유저 정보 요청 생략 커스터마이즈
CustomOAuth2UserService에서 기존 유저 정보를 받아오는 

`  super.loadUser(userRequest)`
로는 정상적인 처리가 되지 않습니다.

해당 loadUser의 경우 인가코드 -> Token -> 유저 정보 의 처리 순서를 따르기에

애플의 인가 코드 -> Token + 유저 정보 Token 로도 유저 정보를 받아오도록 커스터마이즈 해준 loadUser가 필요합니다.

해당 내용은 AppleOAuth2UserService 클래스에서 정의를 해두었습니다.

loadUser 과정은
1. OAuth2UserRequest.getAdditionalParameters().get("id_token")로 id_token 획득

2. Apple의 공개 키 URL (https://appleid.apple.com/auth/keys)에서 JWK 세트 받아오기

3. 서명 검증 (RS256 알고리즘 기반)

4. id_token 디코딩 및 사용자 정보 추출 (예: sub, email)

5. 최종적으로 DefaultOAuth2User 반환
의 5가지 과정이며 
5가지 단계 중 2번과 3번이 Apple OAuth2에서 특히 특이한 부분으로 Apple에서는 id_token에 서명을 자체적으로 제공하는 JWK(JSON Web Key) 세트를 통해 진행합니다.
따라서 이를 검증하기 위해서는 Apple에서 공개하는 JWK 세트를 직접 받아와,
id_token의 서명을 검증하는 과정이 필요합니다.

![image](https://github.com/user-attachments/assets/94515c1b-b6a1-41c3-8521-6123583a6aab)

해당 부분은 Apple의 JWK(JSON Web Key) 세트를 불러오는 로직입니다.
RestTemplate이나 별도의 HTTP 클라이언트를 사용하지 않음에도 동작하는 이유는,
URL 타입의 jwksUrl에 대해 readText()를 호출하면 내부적으로 HTTP 요청이 발생하여
해당 URL의 JSON 데이터를 문자열로 가져오기 때문입니다.

또한, 주석에 명시된 것처럼 JWK 세트는 자주 변경되지 않기 때문에,
한 번 불러온 값을 캐싱해두면 매 요청마다 네트워크를 타지 않게 되어 성능을 향상시킬 수 있지 않을까 싶습니다.


### 결과 화면
![image](https://github.com/user-attachments/assets/d5305f9c-13a7-4a19-970f-0c6810037d44)

정상적으로 Apple Login이 포함됨을 볼 수 있고,
![image](https://github.com/user-attachments/assets/ec7463ed-fef2-4bd8-ac86-9098c5942372)
![image](https://github.com/user-attachments/assets/f8bfcd0d-76b9-432b-87ac-e25d5a9f14d0)
![image](https://github.com/user-attachments/assets/c1c1050d-38f5-4fcb-911f-17390271e62f)

으로 소셜 로그인 이후 회원 가입 페이지로의 redirect를 성공적으로 진행합니다.



## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## 1️⃣ 성능 개선 가능점.
글에서 설명한 것처럼, Apple의 JWK(Public Key Set)를 메모리에 캐싱해두면,
매번 Apple 서버에 요청하지 않아도 되기 때문에 네트워크 I/O를 줄일 수 있으며,
결과적으로 성능 향상이 기대됩니다.

## 2️⃣ 이후 작업 점
1. 소셜 로그인 실패 Exception 작성
2. UserInfo 에서 getName()을 쓸 경우가 없어 이를 삭제하는 작업

## ✍ 궁금한 것
