### PR TITLE
[Fix] : Update workflow to connect to OCI instead of AWS

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -135,14 +135,14 @@ jobs:
       - name: Publish to docker hub
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_IMAGENAME }}
 
-      # AWS Instance 접속 & Application 실행
-      - name: Connect to AWS & Execute Application
+      # OCI Instance 접속 & Application 실행
+      - name: Connect to OCI Instance & Execute Application
         uses: appleboy/ssh-action@v0.1.6
         with:
-          host: ${{ secrets.AWS_HOST }}
-          username: ${{ secrets.AWS_USERNAME }}
-          key: ${{ secrets.AWS_SSH_KEY }}
-          port: ${{ secrets.AWS_SSH_PORT }}
+          host: ${{ secrets.OCI_HOST }}
+          username: ${{ secrets.OCI_USERNAME }}
+          key: ${{ secrets.OCI_SSH_KEY }}
+          port: ${{ secrets.OCI_SSH_PORT }}
           script: |
             cd app/
             docker-compose down


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #170 

## ✅ 작업 내용

- [x] workflow 파일 수정

AWS 프리티어가 만료되었고 신규 계정을 만들 수가 없었기 때문에, 우리 TinU 서비스는 AWS에서 OCI로 이관하기로 결정했습니다.
우선 OCI 계정과 인스턴스를 만들었습니다.
가비아에서 OCI 퍼블릭 IP를 등록한 후 깃허브 Action에서 OCI 인스턴스를 연결하기 위한 작업을 진행했습니다.

다음으로 기존 사용중인 AWS secrets을 대체하는 OCI secrets를 생성했습니다.
해당 secrets들은 HOST, USERNAME, SSH_KEY, SSH_PORT입니다.
기존 ssh-action 라이브러리를 활용하여 손쉽게 갈아 끼울 수 있습니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
