### PR TITLE
[FIX] isSell 필드명을 isSoldOut으로 변경

### DIFF
--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/PostController.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/PostController.kt
@@ -163,11 +163,11 @@ class PostController(
             ]
     )
     fun updatePostStatus(
-            @AuthenticationPrincipal userId: UUID,
-            @PathVariable postId: Long,
-            @RequestParam(required = true) isSell: Boolean
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable postId: Long,
+        @RequestParam(required = true) isSoldOut: Boolean
     ): ResponseEntity<ResponseDTO<NullResponse?>> {
-        postService.updatePostStatus(userId, postId, isSell)
+        postService.updatePostStatus(userId, postId, isSoldOut)
         return ResponseEntityGenerator.onSuccess()
     }
 

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/dto/response/PostDetailResponse.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/dto/response/PostDetailResponse.kt
@@ -29,9 +29,9 @@ data class PostDetailResponse(
         val sellMethod: Set<SellMethod>,
     @Schema(description = "결제 방법", defaultValue = "[0, 1]")
         val paymentMethod: Set<PaymentMethod>,
-    @Schema(description = "판매글 판매 상태", defaultValue = "true")
-        val isSell: Boolean,
-    @Schema(description = "판매글 좋아요 여부", defaultValue = "true")
+    @Schema(description = "판매글 판매 완료 상태(false = 판매 중, true = 판매 완료)", defaultValue = "false")
+        val isSoldOut: Boolean,
+    @Schema(description = "판매글 좋아요 여부(true = 좋아요 상태)", defaultValue = "true")
         val isLike: Boolean,
     @Schema(description = "판매글 좋아요 수", defaultValue = "10")
         val likeCount: Long,

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/dto/response/PostListBodyResponse.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/controller/dto/response/PostListBodyResponse.kt
@@ -19,6 +19,6 @@ data class PostListBodyResponse(
         val isLike: Boolean,
         @Schema(description = "판매글 좋아요 수", defaultValue = "10")
         val likeCount: Long,
-        @Schema(description = "판매글 판매 여부", defaultValue = "true")
-        val isSell: Boolean
+        @Schema(description = "판매글 판매 완료 여부", defaultValue = "false")
+        val isSoldOut: Boolean
 )

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/entity/Post.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/entity/Post.kt
@@ -44,7 +44,7 @@ class Post (
     var sellMethod : Set<SellMethod> = setOf(),
 
     @Column
-    var isSell : Boolean,
+    var isSoldOut : Boolean,
 
     @Column
     var isHide : Boolean = false,

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
@@ -93,7 +93,7 @@ class PostQueryRepositoryImpl(
 
     override fun eqOnlySell(onlySell: Boolean): BooleanExpression? {
         return when (onlySell) {
-            true -> post.isSoldOut.eq(true)
+            true -> post.isSoldOut.eq(false)
             false -> null
         }
     }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/repository/PostQueryRepositoryImpl.kt
@@ -35,7 +35,7 @@ class PostQueryRepositoryImpl(
                         post.thumbnail,
                         ConstantImpl.create(false),
                         post.scrapCount,
-                        post.isSell
+                        post.isSoldOut
                     )
                 )
                 .from(post)
@@ -93,7 +93,7 @@ class PostQueryRepositoryImpl(
 
     override fun eqOnlySell(onlySell: Boolean): BooleanExpression? {
         return when (onlySell) {
-            true -> post.isSell.eq(true)
+            true -> post.isSoldOut.eq(true)
             false -> null
         }
     }

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostService.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostService.kt
@@ -53,7 +53,7 @@ interface PostService {
     fun updatePostStatus(
             userId: UUID,
             postId: Long,
-            isSell: Boolean
+            isSoldOut: Boolean
     )
 
     fun updatePostHide(

--- a/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostServiceImpl.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/post/service/PostServiceImpl.kt
@@ -88,7 +88,7 @@ class PostServiceImpl(
                 thumbnail = post.thumbnail,
                 isLike = post.id in scrapPostIds,
                 likeCount = post.likeCount,
-                isSell = post.isSell
+                isSoldOut = post.isSoldOut
             )
         }
 
@@ -126,7 +126,7 @@ class PostServiceImpl(
                 price = post.price,
                 sellMethod = post.sellMethod.toSet(),
                 paymentMethod = post.paymentMethod.toSet(),
-                isSell = post.isSell,
+                isSoldOut = post.isSoldOut,
                 isLike = member.scrap.any { it.post == post },
                 likeCount = post.scrapCount,
                 isWriter = member == post.author,
@@ -165,7 +165,7 @@ class PostServiceImpl(
                 category = category,
                 price = postCreateRequest.price,
                 sellMethod = postCreateRequest.sellMethod,
-                isSell = true,
+                isSoldOut = false,
                 isHide = false,
                 paymentMethod = postCreateRequest.paymentMethod,
                 thumbnail = urlList.firstOrNull(),
@@ -314,7 +314,7 @@ class PostServiceImpl(
     }
 
     @Transactional
-    override fun updatePostStatus(userId: UUID, postId: Long, isSell: Boolean) {
+    override fun updatePostStatus(userId: UUID, postId: Long, isSoldOut: Boolean) {
 
         log.info("게시글 검증")
         val post = postRepository.findPostById(postId)
@@ -323,7 +323,7 @@ class PostServiceImpl(
         if (userId != post.author.userId)
             throw AuthorNotMatchException()
 
-        post.isSell = isSell
+        post.isSoldOut = isSoldOut
         postRepository.save(post)
     }
 

--- a/src/test/kotlin/com/tinuproject/tinu/factory/TestPostFactory.kt
+++ b/src/test/kotlin/com/tinuproject/tinu/factory/TestPostFactory.kt
@@ -17,7 +17,7 @@ object TestPostFactory {
                 buyer = buyer,
                 category = category,
                 price = 100,
-                isSell = true,
+                isSoldOut = false,
                 thumbnail = null
             )
         )


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #178

## ✅ 작업 내용

- [ ] isSell을 사용하는 필드를 isSoldOut으로 수정

현재 Post에서 사용 중인 isSell은 판매글에 대한 판매 상태를 저장하는 필드입니다.
isSell이 true라면 판매 중, false라면 판매 완료로 사용됩니다.

최근 받은 피드백에서 isSell을 들었을 때 판매 상태라는 뜻으로 이해하기 힘들다는 내용을 반영하여, isSell 필드를 isSoldOut으로 수정했습니다.

isSoldOut은 판매 된 상태를 의미하게 됩니다.
isSoldOut이 true라면 판매 완료, false라면 아직 판매 중이라는 상태로 사용됩니다.

이로써, 논리값이 변경되면서, 서비스 단에서 처리하는 논리값을 반대로 수정하는 작업까지 진행했습니다.

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
