### PR TITLE
[Refactor] : A.T 와 R.T를 Cookie 에서 Header 방식으로 변경

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -101,6 +101,8 @@ jobs:
           apple.team_id= ${{ secrets.APPLE_TEAM_ID }}
           apple.login_key = ${{ secrets.APPLE_LOGIN_KEY }}
           apple.jwk-key-uri = ${{ secrets.APPLE_PUBLIC_KEY_URI }}
+          jwt.header.access-token=Authorization
+          jwt.header.refresh-token=Refresh-Token
           EOF
 
   backend-deploy:

--- a/src/main/kotlin/com/tinuproject/tinu/domain/member/controller/RefreshTokenController.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/domain/member/controller/RefreshTokenController.kt
@@ -9,19 +9,17 @@ import com.tinuproject.tinu.domain.member.service.dto.output.Tokens
 import com.tinuproject.tinu.domain.member.service.RefreshTokenService
 import com.tinuproject.tinu.global.exception.base.BaseException
 import com.tinuproject.tinu.infra.swagger.annotation.SwaggerExceptionResponses
-import com.tinuproject.tinu.global.web.CookieGenerator
 import com.tinuproject.tinu.global.response.dto.NullResponse
 import com.tinuproject.tinu.global.response.ResponseEntityGenerator
+import com.tinuproject.tinu.global.web.RefreshTokenResolver
 import com.tinuproject.tinu.infra.security.exception.auth.NeedLoginException
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.web.server.Cookie
-import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -31,54 +29,32 @@ import org.springframework.web.bind.annotation.RestController
 class RefreshTokenController(
     private val refreshTokenService : RefreshTokenService,
 
-    @Value("\${cookie.token.access-token}")
-    private val accessTokenKey: String,
+    private val refreshTokenResolver: RefreshTokenResolver,
 
-    @Value("\${cookie.token.refresh-token}")
-    private val refreshTokenKey : String,
+    @param:Value("\${jwt.header.access-token}")
+    private val accessTokenHeaderName: String,
 
-    @Value("\${jwt.refresh-token.expiration-time}")
-    private val refreshTokenExpiredTime : Long,
-
-    @Value("\${jwt.access-token.expiration-time}")
-    private val accessTokenExpiredTime : Long
+    @param:Value("\${jwt.header.refresh-token}")
+    private val refreshTokenHeaderName : String,
 ) {
     var log : Logger = LoggerFactory.getLogger(this::class.java)
 
 
-    @GetMapping("/refresh")
+    @GetMapping("/reissue")
     @SwaggerExceptionResponses(exceptions = [NotFoundTokenException::class, InvalidedTokenException::class, ExpiredTokenException::class, ])
     @Operation(summary = "AccessToken 재발급 API", description = "RefreshToken을 통해 AccessToken을 재발급 받는 로직입니다.")
-    fun refreshAccessToken(httpServletResponse: HttpServletResponse, @CookieValue(name = "refresh-token") refreshToken : String?): ResponseEntity<ResponseDTO<NullResponse?>> {
+    fun refreshAccessToken(request : HttpServletRequest, response: HttpServletResponse): ResponseEntity<ResponseDTO<NullResponse?>> {
         log.info("AccessToken 갱신 시도")
 
         try{
-            refreshToken?:throw NotFoundTokenException()
+            val refreshToken = refreshTokenResolver.resolve(request)
 
             val tokens : Tokens = refreshTokenService.reissueAccessTokenByRefreshToken(refreshToken)
 
-            //TODO("이후 프로젝트 완성 시 NONE에서 LAX 로 변경")
-            httpServletResponse.addHeader(
-                HttpHeaders.SET_COOKIE,
-                CookieGenerator.createCookies(
-                    key = accessTokenKey,
-                    value =tokens.accessToken,
-                    sameSite =  Cookie.SameSite.NONE,
-                    maxAge = accessTokenExpiredTime/1000
-                )
-            )
+            response.addHeader(accessTokenHeaderName, "Bearer ${tokens.accessToken}")
 
-            //TODO("이후 프로젝트 완성 시 NONE에서 Strict 로 변경")
-            httpServletResponse.addHeader(
-                HttpHeaders.SET_COOKIE,
-                CookieGenerator.createCookies(
-                    key = refreshTokenKey,
-                    value =  tokens.refreshToken,
-                    path =  "/api/token",
-                    sameSite = Cookie.SameSite.NONE,
-                    maxAge = refreshTokenExpiredTime/1000
-                )
-            )
+            response.addHeader(refreshTokenHeaderName, tokens.refreshToken)
+
             return ResponseEntityGenerator.onSuccess()
         }catch(e : NotFoundTokenException){
             log.warn("RefreshToken이 없습니다. 다시 로그인을 진행해야합니다.")

--- a/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
@@ -3,6 +3,7 @@ package com.tinuproject.tinu.global.web
 import com.tinuproject.tinu.domain.member.exception.InvalidedTokenException
 import com.tinuproject.tinu.domain.member.exception.NotFoundTokenException
 import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
@@ -10,10 +11,12 @@ import org.springframework.stereotype.Component
 class AccessTokenResolver(
     @param:Value("\${jwt.header.access-token}")
     private val accessTokenHeaderName :String
-
 ) : TokenResolver {
 
+    private val  log = LoggerFactory.getLogger(this.javaClass)
+
     override fun resolve(request: HttpServletRequest): String {
+
         val header = request.getHeader(accessTokenHeaderName)
             ?: throw NotFoundTokenException()
 

--- a/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
@@ -1,18 +1,22 @@
 package com.tinuproject.tinu.global.web
 
+import com.tinuproject.tinu.domain.member.exception.InvalidedTokenException
 import com.tinuproject.tinu.domain.member.exception.NotFoundTokenException
 import jakarta.servlet.http.HttpServletRequest
 
 object AccessTokenResolver : TokenResolver {
 
-    private const val ACCESS_TOKEN_COOKIE_NAME = "access-token"
+    private const val ACCESS_TOKEN_HEADER_NAME = "Authorization"
+    private const val BEARER_PREFIX = "Bearer "
 
     override fun resolve(request: HttpServletRequest): String {
-        val cookies = request.cookies ?: throw NotFoundTokenException()
-
-        return cookies
-            .firstOrNull { it.name == ACCESS_TOKEN_COOKIE_NAME }
-            ?.value
+        val header = request.getHeader(ACCESS_TOKEN_HEADER_NAME)
             ?: throw NotFoundTokenException()
+
+        // prefix 체크와 토큰 추출을 동시에 처리
+        return header.takeIf { it.startsWith(BEARER_PREFIX, ignoreCase = true) }
+            ?.removePrefix(BEARER_PREFIX)
+            ?.trim() // 혹시 모를 앞뒤 공백 제거
+            ?: throw InvalidedTokenException()
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
@@ -16,7 +16,7 @@ object AccessTokenResolver : TokenResolver {
         // prefix 체크와 토큰 추출을 동시에 처리
         return header.takeIf { it.startsWith(BEARER_PREFIX, ignoreCase = true) }
             ?.removePrefix(BEARER_PREFIX)
-            ?.trim() // 혹시 모를 앞뒤 공백 제거
+            ?.trim()
             ?: throw InvalidedTokenException()
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/global/web/AccessTokenResolver.kt
@@ -3,14 +3,18 @@ package com.tinuproject.tinu.global.web
 import com.tinuproject.tinu.domain.member.exception.InvalidedTokenException
 import com.tinuproject.tinu.domain.member.exception.NotFoundTokenException
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
 
-object AccessTokenResolver : TokenResolver {
+@Component
+class AccessTokenResolver(
+    @param:Value("\${jwt.header.access-token}")
+    private val accessTokenHeaderName :String
 
-    private const val ACCESS_TOKEN_HEADER_NAME = "Authorization"
-    private const val BEARER_PREFIX = "Bearer "
+) : TokenResolver {
 
     override fun resolve(request: HttpServletRequest): String {
-        val header = request.getHeader(ACCESS_TOKEN_HEADER_NAME)
+        val header = request.getHeader(accessTokenHeaderName)
             ?: throw NotFoundTokenException()
 
         // prefix 체크와 토큰 추출을 동시에 처리
@@ -18,5 +22,9 @@ object AccessTokenResolver : TokenResolver {
             ?.removePrefix(BEARER_PREFIX)
             ?.trim()
             ?: throw InvalidedTokenException()
+    }
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
     }
 }

--- a/src/main/kotlin/com/tinuproject/tinu/global/web/RefreshTokenResolver.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/global/web/RefreshTokenResolver.kt
@@ -1,0 +1,24 @@
+package com.tinuproject.tinu.global.web
+
+import com.tinuproject.tinu.domain.member.exception.InvalidedTokenException
+import com.tinuproject.tinu.domain.member.exception.NotFoundTokenException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class RefreshTokenResolver(
+
+    @param:Value("\${jwt.header.refresh-token}")
+    private val refreshTokenHeaderName: String
+
+) : TokenResolver{
+
+
+    override fun resolve(request: HttpServletRequest): String {
+        val header = request.getHeader(refreshTokenHeaderName)
+            ?: throw NotFoundTokenException()
+
+        return header
+    }
+}

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.tinuproject.tinu.infra.security.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.tinuproject.tinu.domain.member.repository.MemberRepository
+import com.tinuproject.tinu.global.web.AccessTokenResolver
 import com.tinuproject.tinu.infra.security.filter.JwtTokenFilter
 import com.tinuproject.tinu.infra.security.handler.CustomAccessDeniedHandler
 import com.tinuproject.tinu.infra.security.handler.CustomAuthenticationEntryPoint
@@ -46,7 +47,8 @@ class SecurityConfig(
     private val oAuthLoginFailureHandler: OAuthLoginFailureHandler,
     private val customOAuth2UserService: CustomOAuth2UserService,
     private val customAuthenticationEntryPoint: AuthenticationEntryPoint,
-    private val customAccessDeniedHandler: AccessDeniedHandler
+    private val customAccessDeniedHandler: AccessDeniedHandler,
+    private val accessTokenResolver: AccessTokenResolver
 ) {
 
     @Bean
@@ -144,7 +146,7 @@ class SecurityConfig(
             }
 
             httpSecurity
-                .addFilterBefore(JwtTokenFilter(jwtUtil = jwtUtil), UsernamePasswordAuthenticationFilter::class.java)
+                .addFilterBefore(JwtTokenFilter(jwtUtil = jwtUtil,accessTokenResolver=accessTokenResolver), UsernamePasswordAuthenticationFilter::class.java)
 
         return httpSecurity.build()
 

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/filter/JwtTokenFilter.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/filter/JwtTokenFilter.kt
@@ -22,6 +22,8 @@ class JwtTokenFilter(
 
     val jwtUtil : JwtUtil,
 
+    val accessTokenResolver: AccessTokenResolver
+
 ) : OncePerRequestFilter(){
     var log : Logger = LoggerFactory.getLogger(this::class.java);
 
@@ -32,7 +34,7 @@ class JwtTokenFilter(
     ) {
         try {
             // 1. 토큰 추출 (여기서 토큰이 없어서 에러가 나거나 null이면 catch로 빠짐)
-            val accessToken: String = AccessTokenResolver.resolve(request)
+            val accessToken: String = accessTokenResolver.resolve(request)
 
             // 2. 토큰 파싱 및 검증 (만료, 위조 시 예외 발생 -> catch 이동)
             val claims = jwtUtil.getClaimsFromAccessToken(accessToken)

--- a/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/kotlin/com/tinuproject/tinu/infra/security/oauth/handler/OAuthLoginSuccessHandler.kt
@@ -17,6 +17,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.security.core.Authentication
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
 import org.springframework.stereotype.Component
+import org.springframework.web.util.UriComponentsBuilder
 
 import java.util.*
 
@@ -67,15 +68,20 @@ class OAuthLoginSuccessHandler(
             String.format(SIGN_REDIRECT_URL)
         }
 
-        //TODO(이후 프로젝트 완성시  NONE에서 STRICT로 변경)
-        response?.addHeader(HttpHeaders.SET_COOKIE, CookieGenerator.createCookies(
-            key = REFRESH_TOKEN_KEY,
-            value =  refreshToken,
-            path =  "/api/token",
-            sameSite = Cookie.SameSite.NONE,
-            maxAge = jwtProperties.refreshToken.expirationTime/1000
-        ))
-        response?.sendRedirect(redirectUri)
+        //TODO(임시로 쿼리 파람으로 Token을 포함시켜서 응답)
+        //TODO(이후 운영 이전 어떤 방식으로 할 지 추가 논의)
+        val targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+            .queryParam("token", refreshToken)
+            .build().toUriString()
+
+//        response?.addHeader(HttpHeaders.SET_COOKIE, CookieGenerator.createCookies(
+//            key = REFRESH_TOKEN_KEY,
+//            value =  refreshToken,
+//            path =  "/api/token",
+//            sameSite = Cookie.SameSite.NONE,
+//            maxAge = jwtProperties.refreshToken.expirationTime/1000
+//        ))
+        response?.sendRedirect(targetUrl)
     }
 
 

--- a/src/test/kotlin/com/tinuproject/tinu/infra/security/AuthTest.kt
+++ b/src/test/kotlin/com/tinuproject/tinu/infra/security/AuthTest.kt
@@ -129,7 +129,7 @@ class AuthTest (
         )
 
         mockMvc.get("/test/authenticated") {
-            header("Authorization", token)
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isUnauthorized() }
         }

--- a/src/test/kotlin/com/tinuproject/tinu/infra/security/AuthTest.kt
+++ b/src/test/kotlin/com/tinuproject/tinu/infra/security/AuthTest.kt
@@ -98,7 +98,7 @@ class AuthTest (
         )
 
         mockMvc.get("/test/authenticated") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isUnauthorized() }
         }
@@ -114,7 +114,7 @@ class AuthTest (
         )
 
         mockMvc.get("/test/authenticated") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isUnauthorized() }
         }
@@ -129,7 +129,7 @@ class AuthTest (
         )
 
         mockMvc.get("/test/authenticated") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", token)
         }.andExpect {
             status { isUnauthorized() }
         }
@@ -144,7 +144,7 @@ class AuthTest (
         )
 
         mockMvc.get("/test/authenticated") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isUnauthorized() }
         }
@@ -156,7 +156,7 @@ class AuthTest (
         val token = jwtTokenFactory.generateAccessToken(isSign = true)
 
         mockMvc.get("/test/authenticated") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isOk() }
         }
@@ -168,7 +168,7 @@ class AuthTest (
         val token = jwtTokenFactory.generateAccessToken(isSign = true)
 
         mockMvc.get("/test/user") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isOk() }
             content { string("OK") }
@@ -181,7 +181,7 @@ class AuthTest (
         val token = jwtTokenFactory.generateAccessToken(isSign = false)
 
         mockMvc.get("/test/user") {
-            cookie(Cookie("access-token", token))
+            header("Authorization", "Bearer $token")
         }.andExpect {
             status { isForbidden() }
         }


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #186 

## ✅ 작업 내용

- [ ] AccessTokenResolver를 Cookie 에서 Header 방식으로 변경
- [ ] RefershTokenResolver 추가
- [ ] AuthTest AccessToken 넘겨주던 방식 Cookie 에서 Header 로 변경

## 0️⃣ 참고 사항

해당 작업은 저번 Issue에서 진행한 
#176 **Issue175/at cookie refactor** 작업의 반대를 적용한 것으로 구현 부분에서 크게 변화하는 부분이 없어

구현과 관련한 내용은 생략하도록 하겠습니다.

작업 간 의문이 가는 부분이 있을 경우 질문하고 그것에 대해 답을 하는 방식이 좋을 것 같아요!

## 1️⃣ 다시금 A.T와 R.T를 Header로 보내는 작업을 한 이유는 무엇인가.

지난 #176 작업에서 프론트 요구사항에 맞춰 **A.T 전달 방식을 Header에서 Cookie로 변경**하였습니다.
하지만 이번 기획 점검을 통해 **A.T와 R.T 모두를 다시 Header에 담아 응답하는 방식으로 구조를 변경**하게 되었습니다.

이유는 프로젝트의 플랫폼이 웹 브라우저 중심에서 **모바일 앱으로 변경**되었기 때문입니다.
기존 TinU 프로젝트는 웹 서비스만 고려했으나, 제가 이해한 바로는 **웹뷰와 네이티브 컴포넌트? 페이지?가 혼합된 앱 형태**로 서비스를 제공하기로 기획이 변경했다고 이해했습니다.

이 과정에서 **Cookie 기반 인증 방식의 한계가 발생**했습니다.
프론트엔드 구조상 **웹뷰 영역(Next.js 렌더링)**은 **브라우저 스펙인 쿠키 처리에 문제가 없**습니다. 하지만 Next.js 서버를 거치지 않고 **백엔드(Spring Boot) API와 직접 통신하는 순수 네이티브 앱 컴포넌트**에서는 쿠키를 관리하고 전송하는 것이 구조적으로 부적합하여 인증 처리에 난관이 생겼습니다.

이를 해결하기 위해 **프론트/백엔드 회의에서 다음 3가지 대안**을 논의했습니다.

#### 1. A.T와 R.T 모두 Header로 전달 (채택)
#### 2. 앱의 모든 API 요청도 무조건 Next.js 서버를 거치도록(Proxy) 우회 통신
#### 3. 앱용/웹용 API 엔드포인트를 분리하여 토큰 발급 및 관리 방식을 이원화

논의 결과, 2번 방안은 불필요한 네트워크 증가로 인한 트래픽 및 지연 시간 낭비가 우려되었고, 3번 방안은 백엔드 API 설계 복잡도와 프론트엔드의 토큰 관리 로직이 과도하게 비대해진다는 단점이 컸습니다.

따라서 **플랫폼(Web/App)에 구애받지 않는 범용적인 REST API 통신을 위해 1번 방식**을 최종 채택했습니다.
이게 최선이냐 하면 아니라고 생각하지만, 
현재 저희 사이드 프로젝트의 규모와 개발 효율성을 고려했을 때 가장 합리적이고 실용적인 결정이라고 의견을 모았습니다.

## 2️⃣ R.T를 Header로 하게 됨으로써 문제점

이번 작업에서 인증 구조를 변경함에 따라 한 가지 뚜렷한 문제점이 발생했습니다. 바로 소셜 로그인 성공 후, 발급된 Refresh Token(R.T)을 프론트엔드(클라이언트)로 전달하는 방법에 대한 고민이었습니다.


<img width="1112" height="885" alt="제목 없음" src="https://github.com/user-attachments/assets/ddb16ed9-c64b-4f84-80fa-ad20ccb38ff7" />

기존에는 **R.T를 Cookie로 발급**했기 때문에, **백엔드에서 소셜 로그인 프로세스를 모두 마치고 프론트엔드로 Redirect 시킬 때 브라우저가 자동으로 쿠키를 저장**할 수 있었습니다. 

하지만 **Header 방식에서는 HTTP 스펙상 302 Redirect 응답에 커스텀 Header를 실어 보낼 수 없기 때문에 프론트엔드가 R.T를 온전히 수신할 수 없게** 되었습니다.

이를 해결하기 위해 다음 2가지 방안을 두고 논의했습니다.

### 2️⃣ - 1️⃣ 소셜로그인 전반의 책임을 프론트와 백엔드 나누기

소셜 로그인 시 **인증 서버에서 발급되는 인가 코드를 백엔드가 아닌 프론트엔드가 직접 콜백으로 받는 방식**입니다.
프론트엔드가 **획득한 인가 코드를 우리 백엔드 API로 전송**하면, **백엔드가 이를 통해 소셜 서버와 통신하여 유저 정보를 얻고 로그인 처리를 완료**합니다. 

그 후 **A.T와 R.T를 API의 Header로 프론트에 전달**할 수 있습니다.

**단점**으로는 

기존 Spring Security OAuth2 기본 제공 흐름을 크게 수정해야 하므로 당장의 개발 비용과 시간이 많이 소요된다는 점과

저희가 서버에 모든 책임을 뒀던 이유가 프론트에게 인증 과정과 관련한 내용을 노출 시키는 게 맞는가? 에 대한 논의 끝에 백엔드가 담당하기로 했었다는 점이 있습니다.

### 2️⃣ - 2️⃣ 소셜로그인 최종 단계에서 R.T를 획득할 수 있는 방법 추가하기

백엔드 주도의 소셜 로그인 흐름을 유지하되, 

최종 단계에서 프론트엔드로 리다이렉트할 때 URL의 쿼리 파라미터로 인증 수단과 관련한 것을 실어 보내는 방식입니다. 
(예: redirect_uri?token=... or redirect_uri?code=...  ) 

가장 이상적인 것은 일회성 인증 코드(Custom Auth Code)를 자체 발급하여 내려주는 것이지만, 
프론트엔드의 즉각적인 연동과 개발 속도를 위해 약식으로 R.T 자체를 쿼리 파라미터에 담아 전달하도록 설계했습니다.

<img width="682" height="183" alt="image" src="https://github.com/user-attachments/assets/f66b8645-4b3f-4d2a-badf-8e2c2219b663" />

다만 이 방식의 경우에는 URL이 길어지면 R.T를 다 못담을 수도 있고, 보안적으로 아쉬운 점이 있다는 것은 사실입니다.


### 2️⃣ - 3️⃣ 결론 및 향후 계획
현재는 빠른 기능 연동을 위해 **최종 단계 쿼리 파라미터 전달**를 임시 방편으로 구현해 두었습니다.

URL에 토큰이 노출될 경우 브라우저 방문 기록(History)이나 서버 로그 등에 남을 수 있다는 보안적 우려가 존재하지만

현재 저희 프로젝트에는 RTR (Refresh Token Rotation) 방식이 적용되어 있어, 해당 토큰이 일회성으로 동작하므로 
보안 위협을 어느 정도 상쇄할 수 있다고 판단했습니다.

추후 실제 운영 환경으로 전환하거나 여력이 생길 경우, 보안성을 더 높이기 위해 프론트에 인가 코드 전달 방식(그것이 인증서버의 인가코드든, 저희 서버의 인가코드든)로 리팩토링하는 것을 고려하면 좋을 것 같습니다.


## 3️⃣ 프론트 필독 사항(이후 카톡으로도 공유)

Gemini의 응답
프론트엔드 팀원들이 읽고 바로 작업에 착수할 수 있도록, 직관적이고 친절한 "연동 가이드(Action Item)" 형태로 다듬어 보았습니다. PR의 마지막 부분이나 프론트엔드 전달용 노션(Notion)에 그대로 복사해서 쓰시면 완벽합니다!

📢 프론트엔드 연동 가이드 및 주의사항
이번 인증 방식 변경(Header 적용)에 따라, 소셜 로그인 직후의 토큰 수신 및 이후 API 통신 방식이 아래와 같이 변경되었습니다. 프론트엔드 작업 시 참고 부탁드립니다!

1. 소셜 로그인 직후 Refresh Token 수신 (Query Parameter)
백엔드에서 소셜 로그인 처리가 완료되면, 유저의 가입 상태에 따라 아래 URL로 리다이렉트되며 token 파라미터로 **Refresh Token(R.T)**을 전달합니다.
- 신규 회원 (가입 필요 시): /sign-up?token=${R.T}
- 존 회원 (로그인 성공 시): /login?token=${R.T}

>프론트엔드 요청 사항: > 리다이렉트된 페이지가 로드될 때 URL에서 token 값을 추출하여 클라이언트 상태(메모리 등)에 저장해 주세요. 추출 직후에는 브라우저 히스토리에 토큰이 남지 않도록 **URL에서 파라미터를 즉시 지워주시는 것(History Replace)**을 권장한다고 합니다.

#### 해당 방식이 괜찮은지 꼭 확인해주십시오!

2. 이후 API 요청 시 Header 설정
토큰을 획득한 이후부터는, 토큰 재발급(ReIssue) API를 포함하여 인증이 필요한 모든 API 요청 시 발급받은 토큰을 반드시 HTTP Header에 실어 보내주셔야 합니다.
- Access Token (A.T): Authorization 키 사용 (값: Bearer ${A.T}) 
  - 기본적으로 보내줄 때 Bearer ${A.T} 로 보내드립니다.
- Refresh Token (R.T): Refresh-Token 키 사용 (값: ${R.T})

## 📸 스크린샷 / GIF / Link

## 📌 이슈 사항

## ✍ 궁금한 것
